### PR TITLE
updated pytorch, fixed tensorboard, removed clip by open ai

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - click>=8.0
   - pillow=8.3.1
   - scipy=1.7.1
-  - pytorch=1.9.1
+  - pytorch=1.10.2=py3.9_cuda11.3_cudnn8_0  # Specifies CUDA version to stop issue where CPU version is downloaded
   - cudatoolkit>=11.1  # PR #116 by @edstoica
   - requests=2.26.0
   - tqdm=4.62.2
@@ -28,4 +28,4 @@ dependencies:
     - moviepy==1.0.3
     - ffmpeg-python==0.2.0
     - scikit-video==1.1.11
-    - clip-by-openai
+    - setuptools==59.5.0  # Fixes issue where tensorboard errors out with "mobule 'distutils' has no attribute 'version'


### PR DESCRIPTION
Had issues training. Would get different issues.
Specifying pytorch 1.10.2 cuda 11.3 ensures cuda version of pytorch is downloaded.
Removed clip by open AI as that forced torch 1.7.1 due to compability
Added setuptools specification to fix an issue that occasionaly occured with tensorboard when attempting to train.

I do believe this should work without any tweaking. Possibly useful to specify versions of pyspng, psutil and tensorboard to avoid future compability issues