### PR TITLE
Refactor deep dream with anti-saturation, video generation, and improved noise

### DIFF
--- a/discriminator_synthesis.py
+++ b/discriminator_synthesis.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import click
+from dataclasses import dataclass
 from typing import Union, Tuple, Optional, List, Type
 from tqdm import tqdm
 import re
@@ -20,6 +21,7 @@ import re
 from torch_utils import gen_utils
 from network_features import DiscriminatorFeatures
 from fractalperlin import get_2d_perlin, get_3d_perlin
+from pytorch_ssim import gaussian as _gaussian_1d
 
 
 # ----------------------------------------------------------------------------
@@ -300,6 +302,82 @@ def clip(image_tensor: torch.Tensor) -> torch.Tensor:
     return torch.min(torch.max(image_tensor, lo), hi)
 
 
+# ----------------------------------------------------------------------------
+# Anti-saturation helpers. DeepDream ascent on the feature norm, bounded only by a hard clamp,
+# drifts to pure white and pins there. These keep brightness/contrast steady and remove the
+# hard 0/1 pile-up. See the DreamConfig dataclass for the knobs and get_image for starting colors.
+
+
+@dataclass
+class DreamConfig:
+    """Anti-saturation settings threaded through deep_dream()/dream()."""
+    anti_saturation: bool = True         # renormalize to a held mean/std each step
+    soft_clip: bool = True               # smooth (tanh-family) bound instead of hard clamp
+    target_mean: Optional[float] = None  # [0, 1]; None -> hold the starting image's own mean
+    target_std: Optional[float] = None   # [0, 1]; None -> hold the starting image's own std
+    grad_smooth: float = 0.5             # Gaussian sigma to blur the gradient (0 = off)
+    jitter: int = 0                      # max random shift in pixels for the forward pass (0 = off)
+    flip: bool = False                   # random horizontal flip for the forward pass
+
+
+def soft_clip(x: torch.Tensor, lo: float = -1.0, hi: float = 1.0, beta: float = 8.0) -> torch.Tensor:
+    """
+    Softplus-based smooth clamp to [lo, hi]: near-identity in the interior, easing smoothly past the
+    bounds without ever reaching them exactly. Preferred over plain tanh(x), which compresses interior
+    contrast every step and would fight the renormalization into a washed-out result.
+    """
+    x = lo + F.softplus(x - lo, beta=beta)
+    x = hi - F.softplus(hi - x, beta=beta)
+    return x
+
+
+_gauss_window_cache = {}
+
+
+def gaussian_blur(x: torch.Tensor, sigma: float) -> torch.Tensor:
+    """Depthwise Gaussian blur of a (B, C, H, W) tensor; reuses pytorch_ssim's 1D Gaussian."""
+    if sigma <= 0:
+        return x
+    channels = x.shape[1]
+    key = (round(sigma, 3), channels, x.device, x.dtype)
+    window = _gauss_window_cache.get(key)
+    if window is None:
+        radius = max(1, int(round(3 * sigma)))
+        window_size = 2 * radius + 1
+        w1d = _gaussian_1d(window_size, sigma).to(device=x.device, dtype=x.dtype)
+        w2d = torch.outer(w1d, w1d)
+        window = w2d.expand(channels, 1, window_size, window_size).contiguous()
+        _gauss_window_cache[key] = window
+    padding = window.shape[-1] // 2
+    return F.conv2d(x, window, padding=padding, groups=channels)
+
+
+def _resolve_target(image: torch.Tensor, config: DreamConfig) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Resolve the per-sample, per-channel (mean, std) that renormalization holds the image to.
+    Defaults to the input image's own statistics (preserving the starting color/brightness);
+    a flat solid-color start (std ~ 0) falls back to a neutral std so structure can still emerge.
+    Explicit config.target_mean/std are given in [0, 1] and converted to the normalized [-1, 1] space.
+    """
+    neutral_std_norm = 2 * 0.22  # 0.22 in [0, 1] -> normalized space (std scales by 1/0.5)
+    t_mean = image.mean(dim=(2, 3), keepdim=True)
+    t_std = image.std(dim=(2, 3), keepdim=True)
+    t_std = torch.where(t_std < 1e-3, torch.full_like(t_std, neutral_std_norm), t_std)
+    if config.target_mean is not None:
+        t_mean = torch.full_like(t_mean, 2 * config.target_mean - 1)
+    if config.target_std is not None:
+        t_std = torch.full_like(t_std, 2 * config.target_std)
+    return t_mean, t_std
+
+
+def renormalize(image: torch.Tensor, target_mean: torch.Tensor, target_std: torch.Tensor,
+                eps: float = 1e-5) -> torch.Tensor:
+    """Per-sample, per-channel standardize the image back to (target_mean, target_std)."""
+    cur_mean = image.mean(dim=(2, 3), keepdim=True)
+    cur_std = image.std(dim=(2, 3), keepdim=True)
+    return (image - cur_mean) / (cur_std + eps) * target_std + target_mean
+
+
 def dream(image: torch.Tensor,
           model: torch.nn.Module,
           layers: List[str],
@@ -307,21 +385,53 @@ def dream(image: torch.Tensor,
           normed: bool = False,
           sqrt_normed: bool = False,
           iterations: int = 20,
-          lr: float = 1e-2) -> torch.Tensor:
+          lr: float = 1e-2,
+          config: DreamConfig = None,
+          target_mean: torch.Tensor = None,
+          target_std: torch.Tensor = None,
+          generator: torch.Generator = None) -> torch.Tensor:
     """
     Updates the (preprocessed, on-device) image to maximize the chosen layer outputs for n iterations.
     Batches are supported: the loss and the gradient-normalized step are computed per sample,
     so each image in the batch dreams independently, exactly as if processed alone.
+
+    Anti-saturation (via `config`): optional per-forward jitter/flip augmentation, Gaussian blur of
+    the gradient (high-frequency suppression), renormalization to a held mean/std, and a smooth bound
+    replacing the hard clamp. With `config.anti_saturation` off and no blur/jitter it reduces exactly
+    to the original hard-clip ascent.
     """
+    config = config if config is not None else DreamConfig()
+    if config.anti_saturation and target_mean is None:
+        target_mean, target_std = _resolve_target(image, config)
+
     image = image.detach().clone().requires_grad_(True)
     for _ in range(iterations):
-        out = model.get_layers_features(image, layers=layers, channels=channels, normed=normed, sqrt_normed=sqrt_normed)
+        # Optional augmentation for the forward pass only; autograd carries the gradient back to
+        # `image` through the (differentiable) roll/flip, so no manual un-shift is needed.
+        inp = image
+        if config.jitter > 0:
+            sy, sx = torch.randint(-config.jitter, config.jitter + 1, (2,), generator=generator).tolist()
+            inp = torch.roll(inp, shifts=(sy, sx), dims=(2, 3))
+        if config.flip and torch.rand(1, generator=generator).item() < 0.5:
+            inp = torch.flip(inp, dims=[3])
+
+        out = model.get_layers_features(inp, layers=layers, channels=channels, normed=normed, sqrt_normed=sqrt_normed)
         loss = sum(layer.flatten(1).norm(dim=1).sum() for layer in out)  # Per-sample norm; more than one layer may be used
         loss.backward()
         with torch.no_grad():
-            avg_grad = image.grad.abs().mean(dim=(1, 2, 3), keepdim=True)
-            image += lr / (avg_grad + 1e-12) * image.grad
-            image.copy_(clip(image))
+            grad = image.grad
+            if config.grad_smooth > 0:
+                grad = gaussian_blur(grad, config.grad_smooth)
+            avg_grad = grad.abs().mean(dim=(1, 2, 3), keepdim=True)
+            image += lr / (avg_grad + 1e-12) * grad
+            if config.anti_saturation:
+                image.copy_(renormalize(image, target_mean, target_std))
+                if config.soft_clip:
+                    image.copy_(soft_clip(image))
+                else:
+                    image.copy_(clip(image))
+            else:
+                image.copy_(clip(image))
             image.grad.zero_()
     return image.detach()
 
@@ -340,12 +450,18 @@ def deep_dream(image: Union[PIL.Image.Image, torch.Tensor],
                num_octaves: int,
                unzoom_octave: bool = False,
                disable_inner_tqdm: bool = False,
-               ignore_initial_transform: bool = False) -> np.ndarray:
+               ignore_initial_transform: bool = False,
+               config: DreamConfig = None) -> np.ndarray:
     """
     Main deep dream method. `image` can be a PIL.Image (which will be preprocessed) or an
     already-preprocessed tensor of shape (C, H, W) or (1, C, H, W) in normalized [-1, 1] space.
     Everything runs on the model's device; the only CPU transfer is the final deprocessed result.
+
+    Anti-saturation settings are carried in `config` (see DreamConfig); the mean/std target is
+    captured once from the full-resolution input and held across every octave, so global
+    brightness/contrast stays locked to the starting image.
     """
+    config = config if config is not None else DreamConfig()
     device = next(model.parameters()).device
     if isinstance(image, Image.Image):
         # Center-crop and resize
@@ -355,6 +471,23 @@ def deep_dream(image: Union[PIL.Image.Image, torch.Tensor],
     image = image.detach().to(device)
     if image.dim() == 3:
         image = image.unsqueeze(0)
+
+    # Capture the held mean/std target once, from the full-res input (global brightness/contrast lock)
+    target_mean = target_std = None
+    if config.anti_saturation:
+        target_mean, target_std = _resolve_target(image, config)
+
+    # Seed a generator for reproducible jitter/flip augmentation (if enabled). `seed` may be an int,
+    # a list of seeds (batched dream), or None; derive a single int to seed the generator.
+    aug_generator = None
+    if config.jitter > 0 or config.flip:
+        if isinstance(seed, (list, tuple)):
+            seed_val = int(seed[0]) if len(seed) else 0
+        elif seed is not None:
+            seed_val = int(seed)
+        else:
+            seed_val = 0
+        aug_generator = torch.Generator(device='cpu').manual_seed(seed_val)
 
     # Extract image representations for each octave (coarse to fine), on-device
     octaves = [image]
@@ -376,11 +509,51 @@ def deep_dream(image: Union[PIL.Image.Image, torch.Tensor],
             # Upsample detail to new octave dimension
             detail = F.interpolate(detail, size=octave_base.shape[-2:], mode='bilinear', align_corners=False)
         # Add deep dream detail from previous octave to new base, and get new deep dream image
-        dreamed_image = dream(octave_base + detail, model, layers, channels, normed, sqrt_normed, iterations, lr)
+        dreamed_image = dream(octave_base + detail, model, layers, channels, normed, sqrt_normed, iterations, lr,
+                              config=config, target_mean=target_mean, target_std=target_std, generator=aug_generator)
         # Extract deep dream details
         detail = dreamed_image - octave_base
 
     return deprocess(dreamed_image)
+
+
+# ----------------------------------------------------------------------------
+
+
+def saturation_options(default_jitter: int = 0, default_flip: bool = False):
+    """
+    Reusable set of anti-saturation click options shared by all generation commands. Jitter/flip
+    are random per forward pass, so they default off for the sequence commands (per-frame randomness
+    adds flicker) and on for the single-image `dream`. Returns a decorator that stacks the options.
+    """
+    def decorator(func):
+        options = [
+            click.option('--anti-saturation/--no-anti-saturation', 'anti_saturation', default=True, show_default=True,
+                         help='Renormalize to a held mean/std each step so brightness/contrast stay steady (stops the drift to white)'),
+            click.option('--soft-clip/--no-soft-clip', 'soft_clip', default=True, show_default=True,
+                         help='Smoothly bound pixels (tanh-family) instead of a hard 0/1 clamp'),
+            click.option('--target-mean', type=click.FloatRange(0.0, 1.0), default=None,
+                         help='Target pixel mean in [0, 1] to hold (default: the starting image\'s own mean)'),
+            click.option('--target-std', type=click.FloatRange(0.0, 1.0), default=None,
+                         help='Target pixel std in [0, 1] to hold (default: the starting image\'s own std)'),
+            click.option('--grad-smooth', type=click.FloatRange(min=0.0), default=0.5, show_default=True,
+                         help='Gaussian sigma to blur the gradient each step, suppressing high frequencies (0 = off)'),
+            click.option('--jitter', type=click.IntRange(min=0), default=default_jitter, show_default=True,
+                         help='Max random shift in pixels applied to the forward pass (transformation robustness; 0 = off)'),
+            click.option('--flip/--no-flip', 'flip', default=default_flip, show_default=True,
+                         help='Randomly horizontally flip the forward pass (transformation robustness)'),
+        ]
+        for option in reversed(options):
+            func = option(func)
+        return func
+    return decorator
+
+
+def build_dream_config(anti_saturation: bool, soft_clip: bool, target_mean: Optional[float],
+                       target_std: Optional[float], grad_smooth: float, jitter: int, flip: bool) -> DreamConfig:
+    """Assemble a DreamConfig from the saturation_options click params."""
+    return DreamConfig(anti_saturation=anti_saturation, soft_clip=soft_clip, target_mean=target_mean,
+                       target_std=target_std, grad_smooth=grad_smooth, jitter=jitter, flip=flip)
 
 
 # ----------------------------------------------------------------------------
@@ -608,6 +781,8 @@ def style_transfer_discriminator(
 @click.option('--unzoom-octave', type=bool, help='Set to True for the octaves to be unzoomed (this will be slower)', default=True, show_default=True)
 # Performance options
 @click.option('--batch-size', type=click.IntRange(min=1), help='Number of seeds to dream per forward pass (ignored when --layers=all)', default=1, show_default=True)
+# Anti-saturation options (jitter/flip default on for single images)
+@saturation_options(default_jitter=8, default_flip=True)
 # Extra parameters for saving the results
 @click.option('--outdir', type=click.Path(file_okay=False), help='Directory path to save the results', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description name for the directory path to save results', default='', show_default=True)
@@ -630,6 +805,13 @@ def discriminator_dream(
         octave_scale: float,
         unzoom_octave: bool,
         batch_size: int,
+        anti_saturation: bool,
+        soft_clip: bool,
+        target_mean: Optional[float],
+        target_std: Optional[float],
+        grad_smooth: float,
+        jitter: int,
+        flip: bool,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
@@ -647,6 +829,10 @@ def discriminator_dream(
 
     # We will use the features of the Discriminator, on the layer specified by the user
     model = DiscriminatorFeatures(D).requires_grad_(False).to(device)
+
+    # Anti-saturation configuration (shared across all seeds/layers)
+    config = build_dream_config(anti_saturation, soft_clip, target_mean, target_std, grad_smooth, jitter, flip)
+    anti_saturation_cfg = vars(config)
 
     if 'all' in layers:
         # Get all the available layers in a list
@@ -686,6 +872,7 @@ def discriminator_dream(
                     'num_octaves': num_octaves,
                     'octave_scale': octave_scale,
                     'unzoom_octave': unzoom_octave},
+                'anti_saturation_options': anti_saturation_cfg,
                 'extra_parameters': {
                     'outdir': run_dir,
                     'description': description}
@@ -698,7 +885,7 @@ def discriminator_dream(
                 # Extract deep dream image
                 dreamed_image = deep_dream(image, model, model_resolution, layers=[layer], channels=channels, seed=seed, normed=norm_model_layers,
                                            sqrt_normed=sqrt_norm_model_layers, iterations=iterations, lr=learning_rate,
-                                           octave_scale=octave_scale, num_octaves=num_octaves, unzoom_octave=unzoom_octave)
+                                           octave_scale=octave_scale, num_octaves=num_octaves, unzoom_octave=unzoom_octave, config=config)
 
                 # Save the resulting dreamed image
                 filename = f'layer-{layer}_dreamed_{os.path.basename(starting_image).split(".")[0]}.jpg'
@@ -745,7 +932,7 @@ def discriminator_dream(
                                         normed=norm_model_layers, sqrt_normed=sqrt_norm_model_layers,
                                         iterations=iterations, lr=learning_rate, octave_scale=octave_scale,
                                         num_octaves=num_octaves, unzoom_octave=unzoom_octave,
-                                        ignore_initial_transform=True)
+                                        ignore_initial_transform=True, config=config)
             if dreamed_images.ndim == 3:
                 dreamed_images = dreamed_images[None]
 
@@ -779,6 +966,7 @@ def discriminator_dream(
                 'unzoom_octave': unzoom_octave},
             'performance_options': {
                 'batch_size': batch_size},
+            'anti_saturation_options': anti_saturation_cfg,
             'extra_parameters': {
                 'outdir': run_dir,
                 'description': description}
@@ -822,6 +1010,8 @@ def discriminator_dream(
 @click.option('--duration-sec', type=float, help='Duration length of the video', default=15.0, show_default=True)
 @click.option('--reverse-video', is_flag=True, help='Add flag to reverse the generated video')
 @click.option('--include-starting-image', type=bool, help='Include the starting image in the final video', default=True, show_default=True)
+# Anti-saturation options (jitter/flip default off for sequences to preserve temporal coherence)
+@saturation_options()
 # Extra parameters for saving the results
 @click.option('--outdir', type=click.Path(file_okay=False), help='Directory path to save the results', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description name for the directory path to save results', default='', show_default=True)
@@ -851,6 +1041,13 @@ def discriminator_dream_zoom(
         duration_sec: float,
         reverse_video: bool,
         include_starting_image: bool,
+        anti_saturation: bool,
+        soft_clip: bool,
+        target_mean: Optional[float],
+        target_std: Optional[float],
+        grad_smooth: float,
+        jitter: int,
+        flip: bool,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
@@ -875,6 +1072,9 @@ def discriminator_dream_zoom(
 
     # We will use the features of the Discriminator, on the layer specified by the user
     model = DiscriminatorFeatures(D).requires_grad_(False).to(device)
+
+    # Anti-saturation configuration
+    config = build_dream_config(anti_saturation, soft_clip, target_mean, target_std, grad_smooth, jitter, flip)
 
     # Get the image and image name
     image, starting_image = get_image(seed=seed, image_noise=image_noise,
@@ -921,6 +1121,7 @@ def discriminator_dream_zoom(
             'reverse_video': reverse_video,
             'include_starting_image': include_starting_image,
         },
+        'anti_saturation_options': vars(config),
         'extra_parameters': {
             'outdir': run_dir,
             'description': description
@@ -945,7 +1146,7 @@ def discriminator_dream_zoom(
         dreamed_image = deep_dream(image, model, model_resolution, layers=layers, seed=seed, normed=norm_model_layers,
                                    sqrt_normed=sqrt_norm_model_layers, iterations=iterations, channels=channels,
                                    lr=learning_rate, octave_scale=octave_scale, num_octaves=num_octaves,
-                                   unzoom_octave=unzoom_octave, disable_inner_tqdm=True)
+                                   unzoom_octave=unzoom_octave, disable_inner_tqdm=True, config=config)
 
         # Save the resulting image and initial image
         filename = f'dreamed_{idx + 1:0{n_digits}d}.jpg'
@@ -990,6 +1191,8 @@ def discriminator_dream_zoom(
 @click.option('--fps', type=gen_utils.parse_fps, help='FPS for the mp4 video of optimization progress (if saved)', default=25, show_default=True)
 @click.option('--reverse-video', is_flag=True, help='Add flag to reverse the generated video')
 @click.option('--include-starting-image', type=bool, help='Include the starting image in the final video', default=True, show_default=True)
+# Anti-saturation options (jitter/flip default off for sequences to preserve temporal coherence)
+@saturation_options()
 # Extra parameters for saving the results
 @click.option('--outdir', type=click.Path(file_okay=False), help='Directory path to save the results', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description name for the directory path to save results', default='', show_default=True)
@@ -1018,6 +1221,13 @@ def channel_zoom(
         fps: int,
         reverse_video: bool,
         include_starting_image: bool,
+        anti_saturation: bool,
+        soft_clip: bool,
+        target_mean: Optional[float],
+        target_std: Optional[float],
+        grad_smooth: float,
+        jitter: int,
+        flip: bool,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
@@ -1042,6 +1252,9 @@ def channel_zoom(
 
     # We will use the features of the Discriminator, on the layer specified by the user
     model = DiscriminatorFeatures(D).requires_grad_(False).to(device)
+
+    # Anti-saturation configuration
+    config = build_dream_config(anti_saturation, soft_clip, target_mean, target_std, grad_smooth, jitter, flip)
 
     # Get the image and image name
     image, starting_image = get_image(seed=seed, image_noise=image_noise,
@@ -1079,7 +1292,7 @@ def channel_zoom(
         dreamed_image = deep_dream(image, model, model_resolution, layers=layers, seed=seed, normed=norm_model_layers,
                                    sqrt_normed=sqrt_norm_model_layers, iterations=iterations, channels=channels[idx:idx + 1],
                                    lr=learning_rate, octave_scale=octave_scale, num_octaves=num_octaves,
-                                   unzoom_octave=unzoom_octave, disable_inner_tqdm=True)
+                                   unzoom_octave=unzoom_octave, disable_inner_tqdm=True, config=config)
 
         # Save the resulting image and initial image
         filename = f'dreamed_{idx + 1:0{n_digits}d}.jpg'
@@ -1126,6 +1339,7 @@ def channel_zoom(
             'reverse_video': reverse_video,
             'include_starting_image': include_starting_image,
         },
+        'anti_saturation_options': vars(config),
         'extra_parameters': {
             'outdir': run_dir,
             'description': description
@@ -1165,6 +1379,8 @@ def channel_zoom(
 # Video options
 @click.option('--seed-sec', '-sec', type=float, help='Number of seconds between each seed transition', default=5.0, show_default=True)
 @click.option('--fps', type=gen_utils.parse_fps, help='FPS for the mp4 video of optimization progress (if saved)', default=25, show_default=True)
+# Anti-saturation options (jitter/flip default off for sequences to preserve temporal coherence)
+@saturation_options()
 # Extra parameters for saving the results
 @click.option('--outdir', type=click.Path(file_okay=False), help='Directory path to save the results', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description name for the directory path to save results', default='', show_default=True)
@@ -1190,6 +1406,13 @@ def random_interpolation(
         unzoom_octave: Optional[bool],
         seed_sec: float,
         fps: int,
+        anti_saturation: bool,
+        soft_clip: bool,
+        target_mean: Optional[float],
+        target_std: Optional[float],
+        grad_smooth: float,
+        jitter: int,
+        flip: bool,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
@@ -1208,6 +1431,9 @@ def random_interpolation(
     # Get model resolution
     model_resolution = D.img_resolution
     model = DiscriminatorFeatures(D).requires_grad_(False).to(device)
+
+    # Anti-saturation configuration
+    config = build_dream_config(anti_saturation, soft_clip, target_mean, target_std, grad_smooth, jitter, flip)
 
     layers = layers.split(',')
     # Get all available layers
@@ -1262,7 +1488,8 @@ def random_interpolation(
         dreamed_image = deep_dream(image, model, model_resolution, layers=layers, channels=channels, seed=None,
                                    normed=norm_model_layers, disable_inner_tqdm=True, ignore_initial_transform=True,
                                    sqrt_normed=sqrt_norm_model_layers, iterations=iterations, lr=learning_rate,
-                                   octave_scale=octave_scale, num_octaves=num_octaves, unzoom_octave=unzoom_octave)
+                                   octave_scale=octave_scale, num_octaves=num_octaves, unzoom_octave=unzoom_octave,
+                                   config=config)
 
         # Save the resulting image and initial image
         filename = f'{image_noise}-interpolation_frame_{idx:0{n_digits}d}.jpg'
@@ -1286,6 +1513,7 @@ def random_interpolation(
             'octave_scale': octave_scale,
             'num_octaves': num_octaves,
             'unzoom_octave': unzoom_octave},
+        'anti_saturation_options': vars(config),
         'extra_parameters': {
             'outdir': run_dir,
             'description': description}
@@ -1354,7 +1582,8 @@ def _dream_video_worker(rank: int, num_gpus: int, volume_path: str, run_dir: str
                 octave_scale=opts['octave_scale'], num_octaves=opts['num_octaves'],
                 unzoom_octave=opts['unzoom_octave'],
                 disable_inner_tqdm=True,
-                ignore_initial_transform=True
+                ignore_initial_transform=True,
+                config=opts['dream_config']
             )
             if dreamed.ndim == 3:
                 dreamed = dreamed[None]
@@ -1416,6 +1645,8 @@ def combine_axis_videos(video_paths: List[Union[str, os.PathLike]],
 @click.option('--fps', type=gen_utils.parse_fps, help='FPS for the output videos', default=25, show_default=True)
 @click.option('--combine', type=bool, help='Stack the axis videos side by side into a single comparison video', default=True, show_default=True)
 @click.option('--display-height', type=click.IntRange(min=64), help='Height of the combined comparison video', default=512, show_default=True)
+# Anti-saturation options (jitter/flip default off for videos to preserve temporal coherence)
+@saturation_options()
 # Extra parameters
 @click.option('--outdir', type=click.Path(file_okay=False), help='Output directory', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description for output directory', default='', show_default=True)
@@ -1445,6 +1676,13 @@ def discriminator_dream_video(
         fps: int,
         combine: bool,
         display_height: int,
+        anti_saturation: bool,
+        soft_clip: bool,
+        target_mean: Optional[float],
+        target_std: Optional[float],
+        grad_smooth: float,
+        jitter: int,
+        flip: bool,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
@@ -1508,6 +1746,9 @@ def discriminator_dream_video(
     for axis in axes:
         os.makedirs(os.path.join(run_dir, f'axis_{axis}'), exist_ok=True)
 
+    # Anti-saturation configuration (picklable dataclass; passed to each worker)
+    config = build_dream_config(anti_saturation, soft_clip, target_mean, target_std, grad_smooth, jitter, flip)
+
     # Generate the noise volume once and share it with the workers via a memory-mapped file
     print(f'Generating a ({num_frames}, {img_size}, {img_size}) 3D Perlin noise volume...')
     noise_device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
@@ -1534,6 +1775,7 @@ def discriminator_dream_video(
         'axes': axes,
         'multiple': multiple,
         'batch_size': batch_size,
+        'dream_config': config,
     }
 
     if num_gpus > 1:
@@ -1592,6 +1834,7 @@ def discriminator_dream_video(
             'gpus': num_gpus,
             'batch_size': batch_size
         },
+        'anti_saturation_options': vars(config),
         'extra_parameters': {
             'outdir': run_dir,
             'description': description

--- a/discriminator_synthesis.py
+++ b/discriminator_synthesis.py
@@ -90,7 +90,7 @@ def get_image(seed: int = 0,
             noise = noise.cpu().numpy()
             # Stretch to the full [0, 255] range (raw fractal Perlin rarely reaches +-1)
             noise = (noise - noise.min()) / (np.ptp(noise) + 1e-8)
-            image = Image.fromarray((255 * noise).astype(np.uint8).transpose(1, 2, 0), 'RGB')
+            image = Image.fromarray((255 * noise).astype(np.uint8).transpose(1, 2, 0))
 
     if convert_to_grayscale:
         image = image.convert('L').convert('RGB')
@@ -484,7 +484,7 @@ def style_transfer_discriminator(
     output = deprocess(input_img.cpu().data.numpy())
 
     # Save result
-    Image.fromarray(output, 'RGB').save(os.path.join(run_dir, 'stylized.jpg'))
+    Image.fromarray(output).save(os.path.join(run_dir, 'stylized.jpg'))
 
     # Save configuration
     ctx.obj = {
@@ -623,7 +623,7 @@ def discriminator_dream(
 
                 # Save the resulting dreamed image
                 filename = f'layer-{layer}_dreamed_{os.path.basename(starting_image).split(".")[0]}.jpg'
-                Image.fromarray(dreamed_image, 'RGB').save(os.path.join(run_dir, filename))
+                Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
 
     else:
         if 'use_all' in layers:
@@ -658,7 +658,7 @@ def discriminator_dream(
 
             # Save the resulting image and initial image
             filename = f'dreamed_{os.path.basename(starting_image)}'
-            Image.fromarray(dreamed_image, 'RGB').save(os.path.join(run_dir, filename))
+            Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
             image.save(os.path.join(run_dir, os.path.basename(starting_image)))
             starting_image = None
 
@@ -850,10 +850,10 @@ def discriminator_dream_zoom(
 
         # Save the resulting image and initial image
         filename = f'dreamed_{idx + 1:0{n_digits}d}.jpg'
-        Image.fromarray(dreamed_image, 'RGB').save(os.path.join(run_dir, filename))
+        Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
 
         # Now, the dreamed image is the starting image
-        image = Image.fromarray(dreamed_image, 'RGB')
+        image = Image.fromarray(dreamed_image)
 
     # Save the final video
     gen_utils.save_video_from_images(run_dir=run_dir, image_names=f'dreamed_%0{n_digits}d.jpg',
@@ -985,10 +985,10 @@ def channel_zoom(
 
         # Save the resulting image and initial image
         filename = f'dreamed_{idx + 1:0{n_digits}d}.jpg'
-        Image.fromarray(dreamed_image, 'RGB').save(os.path.join(run_dir, filename))
+        Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
 
         # Now, the dreamed image is the starting image
-        image = Image.fromarray(dreamed_image, 'RGB')
+        image = Image.fromarray(dreamed_image)
 
     # Save the final video
     gen_utils.save_video_from_images(run_dir=run_dir, image_names=f'dreamed_%0{n_digits}d.jpg', video_name='channel-zoom',
@@ -1169,7 +1169,7 @@ def random_interpolation(
 
         # Save the resulting image and initial image
         filename = f'{image_noise}-interpolation_frame_{idx:0{n_digits}d}.jpg'
-        Image.fromarray(dreamed_image, 'RGB').save(os.path.join(run_dir, filename))
+        Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
 
     # Save the configuration used
     ctx.obj = {
@@ -1351,7 +1351,7 @@ def discriminator_dream_video(
             # Crop back to the slice size (made even, as yuv420p requires even dimensions)
             dreamed_frame = dreamed_frame[:h - h % 2, :w - w % 2]
             filename = f'frame_{idx:0{n_digits}d}.jpg'
-            Image.fromarray(dreamed_frame, 'RGB').save(os.path.join(axis_dir, filename))
+            Image.fromarray(dreamed_frame).save(os.path.join(axis_dir, filename))
 
         gen_utils.save_video_from_images(run_dir=axis_dir, image_names=f'frame_%0{n_digits}d.jpg',
                                          video_name=f'dream-video-{axis}_axis', fps=fps, reverse_video=False)

--- a/discriminator_synthesis.py
+++ b/discriminator_synthesis.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.autograd import Variable
 from torchvision import transforms
 
 import PIL
@@ -12,10 +11,10 @@ try:
 except ImportError:
     raise ImportError('ffmpeg-python not found! Install it via "pip install ffmpeg-python"')
 
-import scipy.ndimage as nd
 import numpy as np
 
 import os
+import shutil
 import click
 from typing import Union, Tuple, Optional, List, Type
 from tqdm import tqdm
@@ -86,11 +85,12 @@ def get_image(seed: int = 0,
             image = Image.fromarray(rnd.randint(0, 255, (image_size, image_size, 3), dtype='uint8'))
         elif image_noise == 'perlin':
             starting_image = f'perlin_image-seed_{seed:08d}.jpg'
-            # Use our local fractalperlin implementation
-            shape = (3, image_size, image_size)
-            noise = get_2d_perlin(shape, seed=seed, device=device, octaves=6)
-            rgb = (255 * (noise[0].cpu().numpy() + 1) / 2).astype(np.uint8)  # [-1, 1] → [0, 255]
-            image = Image.fromarray(rgb.transpose(1, 2, 0), 'RGB')
+            # Use our local fractalperlin implementation; one independent noise field per RGB channel
+            noise = get_2d_perlin((3, image_size, image_size), seed=seed, device=device, octaves=6)
+            noise = noise.cpu().numpy()
+            # Stretch to the full [0, 255] range (raw fractal Perlin rarely reaches +-1)
+            noise = (noise - noise.min()) / (np.ptp(noise) + 1e-8)
+            image = Image.fromarray((255 * noise).astype(np.uint8).transpose(1, 2, 0), 'RGB')
 
     if convert_to_grayscale:
         image = image.convert('L').convert('RGB')
@@ -98,38 +98,76 @@ def get_image(seed: int = 0,
     return image, starting_image
 
 
-def get_perlin_video(seed: int,
-                     num_frames: int,
-                     image_size: int,
-                     convert_to_grayscale: bool = False,
-                     device: torch.device = torch.device('cuda'),
-                     loop: bool = True) -> Tuple[torch.Tensor, str]:
+def get_perlin_volume(seed: int,
+                      num_frames: int,
+                      image_size: int,
+                      convert_to_grayscale: bool = False,
+                      device: torch.device = torch.device('cuda'),
+                      loop: bool = True,
+                      octaves: int = 6) -> np.ndarray:
     """
-    Generate a video sequence using 3D fractal Perlin noise.
+    Generate a 3D fractal Perlin noise volume that can be sliced along any axis.
 
     Args:
         seed: Random seed
-        num_frames: Number of frames to generate
-        image_size: Size of each frame
-        convert_to_grayscale: Convert to grayscale
-        device: Device for generation
-        loop: If True, video loops seamlessly
+        num_frames: Size of the volume along the time axis
+        image_size: Size of the volume along the y and x axes
+        convert_to_grayscale: Use a single noise field for all three channels
+        device: Device for generation (the volume is returned on CPU)
+        loop: If True, the volume is periodic along the time axis (seamless loop)
+        octaves: Number of fractal octaves to sum
 
     Returns:
-        (Tensor of shape [num_frames, 3, H, W], filename prefix)
+        uint8 array of shape (num_frames, image_size, image_size, 3); the min/max
+        are taken over the whole volume so slices stay temporally consistent
     """
-    shape = (1 if convert_to_grayscale else 3, image_size, image_size)
-    noise = get_3d_perlin(shape, num_frames, seed=seed, device=device, octaves=6, loop=loop)
-
-    # Convert from [-1, 1] to [0, 255]
-    frames = ((noise + 1) / 2 * 255).clamp(0, 255).byte()
-
-    # If grayscale, replicate to 3 channels
+    channels = 1 if convert_to_grayscale else 3
+    noise = get_3d_perlin((channels, image_size, image_size), num_frames, seed=seed,
+                          device=device, octaves=octaves, loop=loop)  # (T, C, H, W)
+    noise = noise.cpu().numpy()
+    noise = (noise - noise.min()) / (np.ptp(noise) + 1e-8)
+    volume = (255 * noise).astype(np.uint8).transpose(0, 2, 3, 1)  # (T, H, W, C)
     if convert_to_grayscale:
-        frames = frames.expand(-1, 3, -1, -1)
+        volume = volume.repeat(3, axis=-1)
+    return volume
 
-    filename_prefix = f'perlin3d_video-seed_{seed:08d}-frames_{num_frames}'
-    return frames, filename_prefix
+
+def get_padding_multiple(layers: List[str], max_resolution: int) -> int:
+    """
+    Smallest power of two that each spatial dimension of an input image must be divisible by,
+    so that the requested Discriminator layers can be computed on inputs of arbitrary size
+    (every block halves the resolution, and the skip/conv branches must stay in sync).
+    """
+    max_down = 0
+    for layer in layers:
+        match = re.match(r'b(\d+)_conv(\d)', layer)
+        if layer == 'from_rgb':
+            down = 0
+        elif match and int(match.group(1)) > 4:
+            res = int(match.group(1))
+            down = int(np.log2(max_resolution // res)) + (1 if match.group(2) == '1' else 0)
+        else:  # 'b4_mbstd', 'b4_conv', 'fc', 'out' traverse the full network
+            down = int(np.log2(max_resolution // 4))
+        max_down = max(max_down, down)
+    return 2 ** max_down
+
+
+def pad_to_multiple(image: torch.Tensor, multiple: int) -> Tuple[torch.Tensor, Tuple[int, int]]:
+    """
+    Tile a (C, H, W) or (B, C, H, W) tensor along its bottom/right edges so both spatial
+    dimensions are multiples of `multiple`. Tiling (rather than zero-padding) keeps the
+    statistics of the noise, and is seamless along a looping Perlin time axis.
+
+    Returns the padded tensor and the original (H, W) to crop the result back.
+    """
+    h, w = image.shape[-2:]
+    new_h = -(-h // multiple) * multiple
+    new_w = -(-w // multiple) * multiple
+    if (new_h, new_w) != (h, w):
+        reps = [1] * image.dim()
+        reps[-2], reps[-1] = -(-new_h // h), -(-new_w // w)
+        image = image.repeat(*reps)[..., :new_h, :new_w]
+    return image, (h, w)
 
 
 def crop_resize_rotate(img: PIL.Image.Image,
@@ -161,55 +199,58 @@ def crop_resize_rotate(img: PIL.Image.Image,
     return img
 
 
-mean = np.array([0.485, 0.456, 0.406])
-std = np.array([0.229, 0.224, 0.225])
+# StyleGAN's Discriminator is fed images in [-1, 1], so we normalize with mean = std = 0.5
+# (the previous ImageNet statistics are a VGG/DeepDream legacy and don't match D's training data)
+mean = np.array([0.5, 0.5, 0.5])
+std = np.array([0.5, 0.5, 0.5])
 
 preprocess = transforms.Compose([transforms.ToTensor(), transforms.Normalize(mean, std)])
 
+# Per-channel bounds in normalized space (the [0, 1] image range maps to these)
+_clip_min = torch.as_tensor((0.0 - mean) / std, dtype=torch.float32).view(1, -1, 1, 1)
+_clip_max = torch.as_tensor((1.0 - mean) / std, dtype=torch.float32).view(1, -1, 1, 1)
 
-def deprocess(image_np: torch.Tensor) -> np.ndarray:
-    image_np = image_np.squeeze().transpose(1, 2, 0)
-    image_np = image_np * std.reshape((1, 1, 3)) + mean.reshape((1, 1, 3))
-    # image_np = (image_np + 1.0) / 2.0
-    image_np = np.clip(image_np, 0.0, 1.0)
-    image_np = (255 * image_np).astype('uint8')
-    return image_np
+
+def deprocess(image: Union[torch.Tensor, np.ndarray]) -> np.ndarray:
+    """Undo the preprocessing normalization and return a uint8 HWC image"""
+    if torch.is_tensor(image):
+        image = image.detach().cpu().numpy()
+    image = image.squeeze().transpose(1, 2, 0)
+    image = image * std.reshape((1, 1, 3)) + mean.reshape((1, 1, 3))
+    image = np.clip(image, 0.0, 1.0)
+    return (255 * image).astype('uint8')
 
 
 def clip(image_tensor: torch.Tensor) -> torch.Tensor:
-    """Clamp per channel"""
-    for c in range(3):
-        m, s = mean[c], std[c]
-        image_tensor[0, c] = torch.clamp(image_tensor[0, c], -m / s, (1 - m) / s)
-    return image_tensor
+    """Clamp per channel to the valid (normalized) image range; vectorized, stays on device"""
+    lo = _clip_min.to(image_tensor.device)
+    hi = _clip_max.to(image_tensor.device)
+    return torch.min(torch.max(image_tensor, lo), hi)
 
 
-def dream(image: PIL.Image.Image,
+def dream(image: torch.Tensor,
           model: torch.nn.Module,
           layers: List[str],
           channels: List[int] = None,
           normed: bool = False,
           sqrt_normed: bool = False,
           iterations: int = 20,
-          lr: float = 1e-2) -> np.ndarray:
-    """ Updates the image to maximize outputs for n iterations """
-    Tensor = torch.cuda.FloatTensor if torch.cuda.is_available() else torch.FloatTensor
-    image = Variable(Tensor(image), requires_grad=True)
-    for i in range(iterations):
-        model.zero_grad()
+          lr: float = 1e-2) -> torch.Tensor:
+    """ Updates the (preprocessed, on-device) image to maximize the chosen layer outputs for n iterations """
+    image = image.detach().clone().requires_grad_(True)
+    for _ in range(iterations):
         out = model.get_layers_features(image, layers=layers, channels=channels, normed=normed, sqrt_normed=sqrt_normed)
         loss = sum(layer.norm() for layer in out)                   # More than one layer may be used
         loss.backward()
-        avg_grad = np.abs(image.grad.data.cpu().numpy()).mean()
-        norm_lr = lr / avg_grad
-        image.data += norm_lr * image.grad.data
-        image.data = clip(image.data)
-        # image.data = torch.clamp(image.data, -1.0, 1.0)
-        image.grad.data.zero_()
-    return image.cpu().data.numpy()
+        with torch.no_grad():
+            avg_grad = image.grad.abs().mean()
+            image += lr / (avg_grad + 1e-12) * image.grad
+            image.copy_(clip(image))
+            image.grad.zero_()
+    return image.detach()
 
 
-def deep_dream(image: PIL.Image.Image,
+def deep_dream(image: Union[PIL.Image.Image, torch.Tensor],
                model: torch.nn.Module,
                model_resolution: int,
                layers: List[str],
@@ -224,35 +265,42 @@ def deep_dream(image: PIL.Image.Image,
                unzoom_octave: bool = False,
                disable_inner_tqdm: bool = False,
                ignore_initial_transform: bool = False) -> np.ndarray:
-    """ Main deep dream method """
-    # Center-crop and resize
-    if not ignore_initial_transform:
-        image = crop_resize_rotate(img=image, crop_size=min(image.size), new_size=model_resolution)
-    # Preprocess image
-    image = preprocess(image)
-    # image = torch.from_numpy(np.array(image)).permute(-1, 0, 1) / 127.5 - 1.0  # alternative
-    image = image.unsqueeze(0).cpu().data.numpy()
-    # Extract image representations for each octave
+    """
+    Main deep dream method. `image` can be a PIL.Image (which will be preprocessed) or an
+    already-preprocessed tensor of shape (C, H, W) or (1, C, H, W) in normalized [-1, 1] space.
+    Everything runs on the model's device; the only CPU transfer is the final deprocessed result.
+    """
+    device = next(model.parameters()).device
+    if isinstance(image, Image.Image):
+        # Center-crop and resize
+        if not ignore_initial_transform:
+            image = crop_resize_rotate(img=image, crop_size=min(image.size), new_size=model_resolution)
+        image = preprocess(image)
+    image = image.detach().to(device)
+    if image.dim() == 3:
+        image = image.unsqueeze(0)
+
+    # Extract image representations for each octave (coarse to fine), on-device
     octaves = [image]
     for _ in range(num_octaves - 1):
-        # Alternatively, see if we get better results with: https://www.tensorflow.org/tutorials/generative/deepdream#taking_it_up_an_octave
-        octave = nd.zoom(octaves[-1], (1, 1, 1 / octave_scale, 1 / octave_scale), order=1)
+        prev = octaves[-1]
+        h, w = prev.shape[-2:]
+        new_size = (max(int(h / octave_scale), 8), max(int(w / octave_scale), 8))
+        octave = F.interpolate(prev, size=new_size, mode='bilinear', align_corners=False)
         # Necessary for StyleGAN's Discriminator, as it cannot handle any image size
         if unzoom_octave:
-            octave = nd.zoom(octave, np.array(octaves[-1].shape) / np.array(octave.shape), order=1)
+            octave = F.interpolate(octave, size=(h, w), mode='bilinear', align_corners=False)
         octaves.append(octave)
 
-    detail = np.zeros_like(octaves[-1])
+    detail = torch.zeros_like(octaves[-1])
     tqdm_desc = f'Dreaming w/layers {"|".join(x for x in layers)}'
     tqdm_desc = f'Seed: {seed} - {tqdm_desc}' if seed is not None else tqdm_desc
-    for octave, octave_base in enumerate(tqdm(octaves[::-1], desc=tqdm_desc, disable=disable_inner_tqdm)):
-        if octave > 0:
+    for octave_idx, octave_base in enumerate(tqdm(octaves[::-1], desc=tqdm_desc, disable=disable_inner_tqdm)):
+        if octave_idx > 0:
             # Upsample detail to new octave dimension
-            detail = nd.zoom(detail, np.array(octave_base.shape) / np.array(detail.shape), order=1)
-        # Add deep dream detail from previous octave to new base
-        input_image = octave_base + detail
-        # Get new deep dream image
-        dreamed_image = dream(input_image, model, layers, channels, normed, sqrt_normed, iterations, lr)
+            detail = F.interpolate(detail, size=octave_base.shape[-2:], mode='bilinear', align_corners=False)
+        # Add deep dream detail from previous octave to new base, and get new deep dream image
+        dreamed_image = dream(octave_base + detail, model, layers, channels, normed, sqrt_normed, iterations, lr)
         # Extract deep dream details
         detail = dreamed_image - octave_base
 
@@ -1149,16 +1197,24 @@ def random_interpolation(
     gen_utils.save_config(ctx=ctx, run_dir=run_dir)
 
     # Generate video
-    print('Saving video...')
-    ffmpeg_command = r'/usr/bin/ffmpeg' if os.name != 'nt' else r'C:\\Ffmpeg\\bin\\ffmpeg.exe'
-    stream = ffmpeg.input(os.path.join(run_dir, f'{image_noise}-interpolation_frame_%0{n_digits}d.jpg'), framerate=fps)
-    stream = ffmpeg.output(stream, os.path.join(run_dir, f'{image_noise}-interpolation.mp4'), crf=20, pix_fmt='yuv420p')
-    ffmpeg.run(stream, capture_stdout=True, capture_stderr=True, cmd=ffmpeg_command)
+    gen_utils.save_video_from_images(run_dir=run_dir, image_names=f'{image_noise}-interpolation_frame_%0{n_digits}d.jpg',
+                                     video_name=f'{image_noise}-interpolation', fps=fps, reverse_video=False)
 
 # ----------------------------------------------------------------------------
 
 
-@main.command(name='dream-video', help='Generate a DeepDream video using 3D fractal Perlin noise for temporal coherence')
+def combine_axis_videos(video_paths: List[Union[str, os.PathLike]],
+                        out_path: Union[str, os.PathLike],
+                        height: int = 512) -> None:
+    """Stack videos side by side (scaled to a common height, trimmed to the shortest one)"""
+    ffmpeg_command = shutil.which('ffmpeg') or 'ffmpeg'
+    streams = [ffmpeg.input(str(p)).filter('scale', -2, height) for p in video_paths]
+    joined = ffmpeg.filter(streams, 'hstack', inputs=len(streams), shortest=1)
+    stream = ffmpeg.output(joined, str(out_path), crf=20, pix_fmt='yuv420p')
+    ffmpeg.run(stream, capture_stdout=True, capture_stderr=True, cmd=ffmpeg_command, overwrite_output=True)
+
+
+@main.command(name='dream-video', help='DeepDream a 3D fractal Perlin noise volume, sliced along the t, y, and/or x axes')
 @click.pass_context
 @click.option('--network', 'network_pkl', help='Network pickle filename', required=True)
 @click.option('--cfg', type=click.Choice(['stylegan3-t', 'stylegan3-r', 'stylegan2']), help='Model base configuration', default=None)
@@ -1173,14 +1229,20 @@ def random_interpolation(
 @click.option('--channels', type=gen_utils.num_range, help='Channel indices to use (None = all)', default=None, show_default=True)
 @click.option('--normed', 'norm_model_layers', is_flag=True, help='Divide features by number of elements')
 @click.option('--sqrt-normed', 'sqrt_norm_model_layers', is_flag=True, help='Divide features by sqrt of number of elements')
-# Octaves options
+# Octaves options (DeepDream image pyramid, not to be confused with the noise octaves)
 @click.option('--num-octaves', type=click.IntRange(min=1), help='Number of octaves', default=5, show_default=True)
 @click.option('--octave-scale', type=float, help='Image scale between octaves', default=1.4, show_default=True)
-@click.option('--unzoom-octave', type=bool, help='Unzoom octaves (slower but works with fixed-size Discriminator)', default=False, show_default=True)
+@click.option('--unzoom-octave', type=bool, help='Unzoom octaves (needed for slices whose size the Discriminator cannot handle)', default=True, show_default=True)
+# Noise volume options
+@click.option('--axes', type=str, help='Comma-separated volume axes to slice along: "t" (xy planes), "y" (tx planes), "x" (ty planes)', default='t,y,x', show_default=True)
+@click.option('--num-frames', type=click.IntRange(min=1), help='Size of the noise volume along the time axis', default=100, show_default=True)
+@click.option('--img-size', type=click.IntRange(min=8), help='Size of the noise volume along the y and x axes (None = Discriminator resolution)', default=None)
+@click.option('--noise-octaves', type=click.IntRange(min=1), help='Number of fractal octaves for the Perlin noise', default=6, show_default=True)
+@click.option('--loop', is_flag=True, help='Make the noise periodic in time, so the t-axis video loops seamlessly')
 # Video options
-@click.option('--num-frames', type=click.IntRange(min=1), help='Number of frames to generate', default=100, show_default=True)
-@click.option('--loop', is_flag=True, help='Make video loop seamlessly')
-@click.option('--fps', type=gen_utils.parse_fps, help='FPS for the output video', default=25, show_default=True)
+@click.option('--fps', type=gen_utils.parse_fps, help='FPS for the output videos', default=25, show_default=True)
+@click.option('--combine', type=bool, help='Stack the axis videos side by side into a single comparison video', default=True, show_default=True)
+@click.option('--display-height', type=click.IntRange(min=64), help='Height of the combined comparison video', default=512, show_default=True)
 # Extra parameters
 @click.option('--outdir', type=click.Path(file_okay=False), help='Output directory', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description for output directory', default='', show_default=True)
@@ -1200,17 +1262,28 @@ def discriminator_dream_video(
         num_octaves: int,
         octave_scale: float,
         unzoom_octave: bool,
+        axes: str,
         num_frames: int,
+        img_size: Optional[int],
+        noise_octaves: int,
         loop: bool,
         fps: int,
+        combine: bool,
+        display_height: int,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
     """
-    Generate a DeepDream video using 3D fractal Perlin noise.
+    Generate DeepDream videos from a single 3D fractal Perlin noise volume.
 
-    Each frame is a slice of 3D noise, providing temporal coherence.
-    Frames are optimized using discriminator features like standard DeepDream.
+    The volume has shape (num_frames, img_size, img_size) and is sliced along each
+    requested axis: 't' yields num_frames xy-slices (the classic video), while 'y'
+    and 'x' yield img_size slices of shape (num_frames, img_size) each. Every slice
+    is DeepDreamed independently with the chosen Discriminator layers; the temporal
+    coherence comes from the smoothness of the noise volume itself.
+
+    Non-square slices are tiled up to a Discriminator-friendly size, dreamed, and
+    cropped back, so the volume dimensions do not need to match the model resolution.
     """
     device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
 
@@ -1226,39 +1299,68 @@ def discriminator_dream_video(
     else:
         available_layers = get_available_layers(max_resolution=model_resolution)
         layers = [layer for layer in layers if layer in available_layers]
+    assert len(layers) > 0, f'No valid layers given! Available layers: {get_available_layers(model_resolution)}'
+
+    # Parse axes
+    axes = [axis.strip() for axis in axes.split(',') if axis.strip()]
+    assert all(axis in ('t', 'y', 'x') for axis in axes), f'Invalid axes "{axes}"; only "t", "y", and "x" are allowed'
+
+    img_size = model_resolution if img_size is None else img_size
+
+    # Both spatial dims of every slice must be divisible by this for the requested layers
+    multiple = get_padding_multiple(layers, model_resolution)
 
     # Make output directory
-    desc = f'discriminator-dream-video-{num_frames}frames'
+    desc = f'discriminator-dream-video-axes_{"-".join(axes)}'
     desc = f'{desc}-{description}' if description else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
 
-    print(f'Generating {num_frames} frames of 3D Perlin noise...')
-    noise_frames, _ = get_perlin_video(seed, num_frames, model_resolution, convert_to_grayscale, device, loop)
+    print(f'Generating a ({num_frames}, {img_size}, {img_size}) 3D Perlin noise volume...')
+    volume = get_perlin_volume(seed, num_frames, img_size, convert_to_grayscale, device, loop, noise_octaves)
 
-    # Number of digits for frame numbering
-    n_digits = int(np.log10(num_frames)) + 1
+    axis_videos = []
+    for axis in axes:
+        # Slice the volume perpendicular to the chosen axis; first dim indexes the slices
+        if axis == 't':
+            slices = volume                              # (T, H, W, C): xy planes
+        elif axis == 'y':
+            slices = volume.transpose(1, 0, 2, 3)        # (H, T, W, C): tx planes
+        else:
+            slices = volume.transpose(2, 0, 1, 3)        # (W, T, H, C): ty planes
 
-    print(f'Applying DeepDream to each frame...')
-    for frame_idx in tqdm(range(num_frames), desc='Dreaming', unit='frame'):
-        # Get frame as PIL Image
-        frame_np = noise_frames[frame_idx].cpu().numpy().transpose(1, 2, 0)
-        frame_pil = Image.fromarray(frame_np)
+        axis_dir = os.path.join(run_dir, f'axis_{axis}')
+        os.makedirs(axis_dir, exist_ok=True)
+        n_digits = int(np.log10(len(slices))) + 1
 
-        # Apply DeepDream to this frame
-        dreamed_frame = deep_dream(
-            frame_pil, model, model_resolution,
-            layers=layers, channels=channels, seed=None,
-            normed=norm_model_layers, sqrt_normed=sqrt_norm_model_layers,
-            iterations=iterations, lr=learning_rate,
-            octave_scale=octave_scale, num_octaves=num_octaves,
-            unzoom_octave=unzoom_octave,
-            disable_inner_tqdm=True,
-            ignore_initial_transform=True
-        )
+        for idx, slice_np in enumerate(tqdm(slices, desc=f'Dreaming along the {axis}-axis', unit='frame')):
+            # Preprocess the slice and tile it up to a Discriminator-friendly size
+            slice_tensor = preprocess(np.ascontiguousarray(slice_np))
+            slice_tensor, (h, w) = pad_to_multiple(slice_tensor, multiple)
 
-        # Save frame
-        filename = f'frame_{frame_idx:0{n_digits}d}.jpg'
-        Image.fromarray(dreamed_frame, 'RGB').save(os.path.join(run_dir, filename))
+            dreamed_frame = deep_dream(
+                slice_tensor, model, model_resolution,
+                layers=layers, channels=channels, seed=None,
+                normed=norm_model_layers, sqrt_normed=sqrt_norm_model_layers,
+                iterations=iterations, lr=learning_rate,
+                octave_scale=octave_scale, num_octaves=num_octaves,
+                unzoom_octave=unzoom_octave,
+                disable_inner_tqdm=True,
+                ignore_initial_transform=True
+            )
+
+            # Crop back to the slice size (made even, as yuv420p requires even dimensions)
+            dreamed_frame = dreamed_frame[:h - h % 2, :w - w % 2]
+            filename = f'frame_{idx:0{n_digits}d}.jpg'
+            Image.fromarray(dreamed_frame, 'RGB').save(os.path.join(axis_dir, filename))
+
+        gen_utils.save_video_from_images(run_dir=axis_dir, image_names=f'frame_%0{n_digits}d.jpg',
+                                         video_name=f'dream-video-{axis}_axis', fps=fps, reverse_video=False)
+        axis_videos.append(os.path.join(axis_dir, f'dream-video-{axis}_axis.mp4'))
+
+    # Stack the axis videos side by side for easy comparison
+    if combine and len(axis_videos) > 1:
+        print('Combining the axis videos side by side...')
+        combine_axis_videos(axis_videos, os.path.join(run_dir, 'dream-video-combined.mp4'), height=display_height)
 
     # Save configuration
     ctx.obj = {
@@ -1282,9 +1384,14 @@ def discriminator_dream_video(
             'unzoom_octave': unzoom_octave
         },
         'video_options': {
+            'axes': axes,
             'num_frames': num_frames,
+            'img_size': img_size,
+            'noise_octaves': noise_octaves,
             'loop': loop,
-            'fps': fps
+            'fps': fps,
+            'combine': combine,
+            'display_height': display_height
         },
         'extra_parameters': {
             'outdir': run_dir,
@@ -1293,15 +1400,7 @@ def discriminator_dream_video(
     }
     gen_utils.save_config(ctx=ctx, run_dir=run_dir)
 
-    # Generate video
-    print('Saving video...')
-    gen_utils.save_video_from_images(
-        run_dir=run_dir,
-        image_names=f'frame_%0{n_digits}d.jpg',
-        video_name='dream-video',
-        fps=fps,
-        reverse_video=False
-    )
+    print(f'Done! Results saved to {run_dir}')
 
 
 # ----------------------------------------------------------------------------

--- a/discriminator_synthesis.py
+++ b/discriminator_synthesis.py
@@ -5,17 +5,13 @@ import torch.multiprocessing
 from torchvision import transforms
 
 import PIL
-from PIL import Image
-
-try:
-    import ffmpeg
-except ImportError:
-    raise ImportError('ffmpeg-python not found! Install it via "pip install ffmpeg-python"')
+from PIL import Image, ImageColor
 
 import numpy as np
 
 import os
 import shutil
+import subprocess
 import click
 from typing import Union, Tuple, Optional, List, Type
 from tqdm import tqdm
@@ -52,6 +48,68 @@ def get_available_layers(max_resolution: int) -> List[str]:
 
 
 # ----------------------------------------------------------------------------
+
+
+def get_model_name(network_pkl: Union[str, os.PathLike], cfg: Optional[str] = None, max_length: int = 10) -> str:
+    """
+    Compact model name for directory/file naming. Known model names from gen_utils.resume_specs
+    (e.g., 'ffhq1024', 'metfaces1024') are used in full; otherwise the file name of the local
+    path or URL (whatever precedes '.pkl') is used, shortened to max_length characters.
+    """
+    network_pkl = str(network_pkl)
+    if cfg is not None and network_pkl in gen_utils.resume_specs.get(cfg, {}):
+        return network_pkl
+    name = network_pkl.replace('\\', '/').split('/')[-1].split('.pkl')[0]
+    return name[:max_length] if len(name) > max_length else name
+
+
+def get_run_desc(network_pkl: Union[str, os.PathLike], cfg: Optional[str], *parts: str) -> str:
+    """Build a run directory description: '<model_name>[-<cfg>]-<part>-<part>-...'"""
+    return '-'.join([get_model_name(network_pkl, cfg)] + ([cfg] if cfg is not None else []) + [p for p in parts if p])
+
+
+def layers_tag(layers: List[str], max_layers: int = 3) -> str:
+    """Compact tag describing the layers used, for directory naming"""
+    return '-'.join(layers) if len(layers) <= max_layers else f'{len(layers)}_layers'
+
+
+# ----------------------------------------------------------------------------
+# Video helpers: call the ffmpeg binary directly via subprocess
+
+
+def _ffmpeg_bin() -> str:
+    ffmpeg_bin = shutil.which('ffmpeg')
+    if ffmpeg_bin is None:
+        raise RuntimeError('ffmpeg not found! Install it and make sure it is in your PATH.')
+    return ffmpeg_bin
+
+
+def save_video_ffmpeg(frames_dir: Union[str, os.PathLike],
+                      image_pattern: str,
+                      video_name: str,
+                      fps: int = 30,
+                      crf: int = 20,
+                      preset: str = 'veryfast',
+                      reverse_video: bool = False) -> str:
+    """
+    Assemble the frames matching `image_pattern` (printf-style, e.g. 'frame_%04d.jpg') in
+    `frames_dir` into an .mp4, by invoking the ffmpeg binary directly. Returns the video path.
+    """
+    video_path = os.path.join(frames_dir, f'{video_name}.mp4')
+    print(f'Saving video to "{video_path}"...')
+    subprocess.run([_ffmpeg_bin(), '-y', '-loglevel', 'error',
+                    '-framerate', str(fps), '-i', os.path.join(frames_dir, image_pattern),
+                    '-c:v', 'libx264', '-preset', preset, '-crf', str(crf), '-pix_fmt', 'yuv420p',
+                    video_path], check=True)
+    if reverse_video:
+        # Save the reversed video apart from the original one, so the user can compare both
+        subprocess.run([_ffmpeg_bin(), '-y', '-loglevel', 'error', '-i', video_path,
+                        '-vf', 'reverse', '-c:v', 'libx264', '-preset', preset, '-crf', str(crf),
+                        '-pix_fmt', 'yuv420p', os.path.join(frames_dir, f'{video_name}_reversed.mp4')], check=True)
+    return video_path
+
+
+# ----------------------------------------------------------------------------
 # DeepDream code; modified from Erik Linder-Norén's repository: https://github.com/eriklindernoren/PyTorch-Deep-Dream
 
 def get_image(seed: int = 0,
@@ -65,7 +123,8 @@ def get_image(seed: int = 0,
 
     Args:
         seed: Random seed for reproducibility
-        image_noise: Type of noise ('random' or 'perlin')
+        image_noise: 'random', 'perlin', or any solid color understood by PIL
+                     (a name like 'white'/'black'/'red', or hex like '#ff8800')
         starting_image: Path to existing image (if None, generates new)
         image_size: Size of generated image
         convert_to_grayscale: Convert to grayscale
@@ -92,6 +151,15 @@ def get_image(seed: int = 0,
             # Stretch to the full [0, 255] range (raw fractal Perlin rarely reaches +-1)
             noise = (noise - noise.min()) / (np.ptp(noise) + 1e-8)
             image = Image.fromarray((255 * noise).astype(np.uint8).transpose(1, 2, 0))
+        else:
+            # Treat anything else as a solid color (e.g., 'white', 'black', 'red', '#ff8800')
+            try:
+                color = ImageColor.getrgb(image_noise)
+            except ValueError:
+                raise ValueError(f'Unknown image noise type/color "{image_noise}"! Use "random", "perlin", '
+                                 'or any color name/hex code understood by PIL (e.g., "white", "#ff8800")')
+            starting_image = f'{image_noise.replace("#", "hex")}_image.jpg'
+            image = Image.new('RGB', (image_size, image_size), color)
 
     if convert_to_grayscale:
         image = image.convert('L').convert('RGB')
@@ -437,7 +505,7 @@ def style_transfer_discriminator(
     optimizer = torch.optim.LBFGS([input_img], lr=lr, max_iter=20)
 
     # Make output directory
-    desc = 'discriminator-style-transfer'
+    desc = get_run_desc(network_pkl, cfg, 'style-transfer')
     desc = f'{desc}-{description}' if description else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
 
@@ -523,7 +591,7 @@ def style_transfer_discriminator(
 @click.option('--cfg', type=click.Choice(['stylegan3-t', 'stylegan3-r', 'stylegan2']), help='Model base configuration', default=None)
 # Synthesis options
 @click.option('--seeds', type=gen_utils.num_range, help='Random seeds to use. Accepted comma-separated values, ranges, or combinations: "a,b,c", "a-c", "a,b-d,e".', default='0')
-@click.option('--random-image-noise', '-noise', 'image_noise', type=click.Choice(['random', 'perlin']), default='perlin', show_default=True)
+@click.option('--random-image-noise', '-noise', 'image_noise', type=str, help='Starting image content: "random" noise, "perlin" noise, or any solid color understood by PIL (e.g., "white", "black", "#ff8800")', default='perlin', show_default=True)
 @click.option('--starting-image', type=str, help='Path to image to start from', default=None)
 @click.option('--convert-to-grayscale', '-grayscale', is_flag=True, help='Add flag to grayscale the initial image')
 @click.option('--class', 'class_idx', type=int, help='Class label (unconditional if not specified)', default=None)
@@ -592,7 +660,7 @@ def discriminator_dream(
                                               convert_to_grayscale=convert_to_grayscale)
 
             # Make the run dir in the specified output directory
-            desc = f'discriminator-dream-all_layers-seed_{seed}'
+            desc = get_run_desc(network_pkl, cfg, 'dream-all_layers', f'seed_{seed}')
             desc = f'{desc}-{description}' if len(description) != 0 else desc
             run_dir = gen_utils.make_run_dir(outdir, desc)
 
@@ -646,7 +714,7 @@ def discriminator_dream(
             layers = [layer for layer in layers if layer in available_layers]
 
         # Make the run dir in the specified output directory
-        desc = f'discriminator-dream-layers_{"-".join(x for x in layers)}'
+        desc = get_run_desc(network_pkl, cfg, 'dream', f'layers_{layers_tag(layers)}')
         desc = f'{desc}-{description}' if len(description) != 0 else desc
         run_dir = gen_utils.make_run_dir(outdir, desc)
 
@@ -729,7 +797,7 @@ def discriminator_dream(
 @click.option('--cfg', type=click.Choice(['stylegan3-t', 'stylegan3-r', 'stylegan2']), help='Model base configuration', default=None)
 # Synthesis options
 @click.option('--seed', type=int, help='Random seed to use', default=0, show_default=True)
-@click.option('--random-image-noise', '-noise', 'image_noise', type=click.Choice(['random', 'perlin']), default='random', show_default=True)
+@click.option('--random-image-noise', '-noise', 'image_noise', type=str, help='Starting image content: "random" noise, "perlin" noise, or any solid color understood by PIL (e.g., "white", "black", "#ff8800")', default='random', show_default=True)
 @click.option('--starting-image', type=str, help='Path to image to start from', default=None)
 @click.option('--convert-to-grayscale', '-grayscale', is_flag=True, help='Add flag to grayscale the initial image')
 @click.option('--class', 'class_idx', type=int, help='Class label (unconditional if not specified)', default=None)
@@ -815,7 +883,7 @@ def discriminator_dream_zoom(
                                       convert_to_grayscale=convert_to_grayscale)
 
     # Make the run dir in the specified output directory
-    desc = 'discriminator-dream-zoom'
+    desc = get_run_desc(network_pkl, cfg, 'dream-zoom', f'layers_{layers_tag(layers)}')
     desc = f'{desc}-{description}' if len(description) != 0 else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
 
@@ -887,8 +955,7 @@ def discriminator_dream_zoom(
         image = Image.fromarray(dreamed_image)
 
     # Save the final video
-    gen_utils.save_video_from_images(run_dir=run_dir, image_names=f'dreamed_%0{n_digits}d.jpg',
-                                     video_name='dream-zoom', fps=fps, reverse_video=reverse_video)
+    save_video_ffmpeg(run_dir, f'dreamed_%0{n_digits}d.jpg', 'dream-zoom', fps=fps, reverse_video=reverse_video)
 
 
 # ----------------------------------------------------------------------------
@@ -899,7 +966,7 @@ def discriminator_dream_zoom(
 @click.option('--cfg', type=click.Choice(['stylegan3-t', 'stylegan3-r', 'stylegan2']), help='Model base configuration', default=None)
 # Synthesis options
 @click.option('--seed', type=int, help='Random seed to use', default=0, show_default=True)
-@click.option('--random-image-noise', '-noise', 'image_noise', type=click.Choice(['random', 'perlin']), default='random', show_default=True)
+@click.option('--random-image-noise', '-noise', 'image_noise', type=str, help='Starting image content: "random" noise, "perlin" noise, or any solid color understood by PIL (e.g., "white", "black", "#ff8800")', default='random', show_default=True)
 @click.option('--starting-image', type=str, help='Path to image to start from', default=None)
 @click.option('--convert-to-grayscale', '-grayscale', is_flag=True, help='Add flag to grayscale the initial image')
 @click.option('--class', 'class_idx', type=int, help='Class label (unconditional if not specified)', default=None)
@@ -983,7 +1050,7 @@ def channel_zoom(
                                       convert_to_grayscale=convert_to_grayscale)
 
     # Make the run dir in the specified output directory
-    desc = 'discriminator-channel-zoom'
+    desc = get_run_desc(network_pkl, cfg, 'channel-zoom', f'layer_{layer}')
     desc = f'{desc}-{description}' if len(description) != 0 else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
 
@@ -1022,8 +1089,7 @@ def channel_zoom(
         image = Image.fromarray(dreamed_image)
 
     # Save the final video
-    gen_utils.save_video_from_images(run_dir=run_dir, image_names=f'dreamed_%0{n_digits}d.jpg', video_name='channel-zoom',
-                                     fps=fps, reverse_video=reverse_video)
+    save_video_ffmpeg(run_dir, f'dreamed_%0{n_digits}d.jpg', 'channel-zoom', fps=fps, reverse_video=reverse_video)
 
     # Save the configuration used
     ctx.obj = {
@@ -1080,7 +1146,7 @@ def channel_zoom(
 @click.option('--seeds', type=gen_utils.num_range, help='Random seeds to generate the Perlin noise from', required=True)
 @click.option('--interp-type', '-interp', type=click.Choice(['linear', 'spherical']), help='Type of interpolation in Z or W', default='spherical', show_default=True)
 @click.option('--smooth', is_flag=True, help='Add flag to smooth the interpolation between the seeds')
-@click.option('--random-image-noise', '-noise', 'image_noise', type=click.Choice(['random', 'perlin']), default='random', show_default=True)
+@click.option('--random-image-noise', '-noise', 'image_noise', type=str, help='Starting image content: "random" noise, "perlin" noise, or any solid color understood by PIL (e.g., "white", "black", "#ff8800")', default='random', show_default=True)
 @click.option('--starting-image', type=str, help='Path to image to start from', default=None)
 @click.option('--convert-to-grayscale', '-grayscale', is_flag=True, help='Add flag to grayscale the initial image')
 @click.option('--class', 'class_idx', type=int, help='Class label (unconditional if not specified)', default=None)
@@ -1153,7 +1219,7 @@ def random_interpolation(
         layers = [layer for layer in layers if layer in available_layers]
 
     # Make the run dir in the specified output directory
-    desc = f'random-interp-layers_{"-".join(x for x in layers)}'
+    desc = get_run_desc(network_pkl, cfg, 'interp', f'layers_{layers_tag(layers)}')
     desc = f'{desc}-{description}' if len(description) != 0 else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
 
@@ -1228,8 +1294,7 @@ def random_interpolation(
     gen_utils.save_config(ctx=ctx, run_dir=run_dir)
 
     # Generate video
-    gen_utils.save_video_from_images(run_dir=run_dir, image_names=f'{image_noise}-interpolation_frame_%0{n_digits}d.jpg',
-                                     video_name=f'{image_noise}-interpolation', fps=fps, reverse_video=False)
+    save_video_ffmpeg(run_dir, f'{image_noise}-interpolation_frame_%0{n_digits}d.jpg', f'{image_noise}-interpolation', fps=fps)
 
 # ----------------------------------------------------------------------------
 
@@ -1304,13 +1369,19 @@ def _dream_video_worker(rank: int, num_gpus: int, volume_path: str, run_dir: str
 
 def combine_axis_videos(video_paths: List[Union[str, os.PathLike]],
                         out_path: Union[str, os.PathLike],
-                        height: int = 512) -> None:
+                        height: int = 512,
+                        crf: int = 20,
+                        preset: str = 'veryfast') -> None:
     """Stack videos side by side (scaled to a common height, trimmed to the shortest one)"""
-    ffmpeg_command = shutil.which('ffmpeg') or 'ffmpeg'
-    streams = [ffmpeg.input(str(p)).filter('scale', -2, height) for p in video_paths]
-    joined = ffmpeg.filter(streams, 'hstack', inputs=len(streams), shortest=1)
-    stream = ffmpeg.output(joined, str(out_path), crf=20, pix_fmt='yuv420p')
-    ffmpeg.run(stream, capture_stdout=True, capture_stderr=True, cmd=ffmpeg_command, overwrite_output=True)
+    n = len(video_paths)
+    cmd = [_ffmpeg_bin(), '-y', '-loglevel', 'error']
+    for path in video_paths:
+        cmd += ['-i', str(path)]
+    filters = ';'.join(f'[{i}:v]scale=-2:{height}[v{i}]' for i in range(n))
+    filters += ';' + ''.join(f'[v{i}]' for i in range(n)) + f'hstack=inputs={n}:shortest=1[out]'
+    cmd += ['-filter_complex', filters, '-map', '[out]',
+            '-c:v', 'libx264', '-preset', preset, '-crf', str(crf), '-pix_fmt', 'yuv420p', str(out_path)]
+    subprocess.run(cmd, check=True)
 
 
 @main.command(name='dream-video', help='DeepDream a 3D fractal Perlin noise volume, sliced along the t, y, and/or x axes')
@@ -1431,7 +1502,7 @@ def discriminator_dream_video(
     multiple = get_padding_multiple(layers, model_resolution)
 
     # Make output directory
-    desc = f'discriminator-dream-video-axes_{"-".join(axes)}'
+    desc = get_run_desc(network_pkl, cfg, 'dream-video', f'axes_{"-".join(axes)}', f'layers_{layers_tag(layers)}')
     desc = f'{desc}-{description}' if description else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
     for axis in axes:
@@ -1478,8 +1549,7 @@ def discriminator_dream_video(
         num_slices = num_frames if axis == 't' else img_size
         n_digits = int(np.log10(num_slices)) + 1
         axis_dir = os.path.join(run_dir, f'axis_{axis}')
-        gen_utils.save_video_from_images(run_dir=axis_dir, image_names=f'frame_%0{n_digits}d.jpg',
-                                         video_name=f'dream-video-{axis}_axis', fps=fps, reverse_video=False)
+        save_video_ffmpeg(axis_dir, f'frame_%0{n_digits}d.jpg', f'dream-video-{axis}_axis', fps=fps)
         axis_videos.append(os.path.join(axis_dir, f'dream-video-{axis}_axis.mp4'))
 
     # Stack the axis videos side by side for easy comparison

--- a/discriminator_synthesis.py
+++ b/discriminator_synthesis.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.multiprocessing
 from torchvision import transforms
 
 import PIL
@@ -212,10 +213,13 @@ _clip_max = torch.as_tensor((1.0 - mean) / std, dtype=torch.float32).view(1, -1,
 
 
 def deprocess(image: Union[torch.Tensor, np.ndarray]) -> np.ndarray:
-    """Undo the preprocessing normalization and return a uint8 HWC image"""
+    """Undo the preprocessing normalization; returns a uint8 HWC image,
+    or a BHWC stack if a batch of more than one image is given"""
     if torch.is_tensor(image):
         image = image.detach().cpu().numpy()
-    image = image.squeeze().transpose(1, 2, 0)
+    if image.ndim == 4 and image.shape[0] == 1:
+        image = image[0]
+    image = image.transpose(0, 2, 3, 1) if image.ndim == 4 else image.transpose(1, 2, 0)
     image = image * std.reshape((1, 1, 3)) + mean.reshape((1, 1, 3))
     image = np.clip(image, 0.0, 1.0)
     return (255 * image).astype('uint8')
@@ -236,14 +240,18 @@ def dream(image: torch.Tensor,
           sqrt_normed: bool = False,
           iterations: int = 20,
           lr: float = 1e-2) -> torch.Tensor:
-    """ Updates the (preprocessed, on-device) image to maximize the chosen layer outputs for n iterations """
+    """
+    Updates the (preprocessed, on-device) image to maximize the chosen layer outputs for n iterations.
+    Batches are supported: the loss and the gradient-normalized step are computed per sample,
+    so each image in the batch dreams independently, exactly as if processed alone.
+    """
     image = image.detach().clone().requires_grad_(True)
     for _ in range(iterations):
         out = model.get_layers_features(image, layers=layers, channels=channels, normed=normed, sqrt_normed=sqrt_normed)
-        loss = sum(layer.norm() for layer in out)                   # More than one layer may be used
+        loss = sum(layer.flatten(1).norm(dim=1).sum() for layer in out)  # Per-sample norm; more than one layer may be used
         loss.backward()
         with torch.no_grad():
-            avg_grad = image.grad.abs().mean()
+            avg_grad = image.grad.abs().mean(dim=(1, 2, 3), keepdim=True)
             image += lr / (avg_grad + 1e-12) * image.grad
             image.copy_(clip(image))
             image.grad.zero_()
@@ -530,6 +538,8 @@ def style_transfer_discriminator(
 @click.option('--num-octaves', type=int, help='Number of octaves', default=5, show_default=True)
 @click.option('--octave-scale', type=float, help='Image scale between octaves', default=1.4, show_default=True)
 @click.option('--unzoom-octave', type=bool, help='Set to True for the octaves to be unzoomed (this will be slower)', default=True, show_default=True)
+# Performance options
+@click.option('--batch-size', type=click.IntRange(min=1), help='Number of seeds to dream per forward pass (ignored when --layers=all)', default=1, show_default=True)
 # Extra parameters for saving the results
 @click.option('--outdir', type=click.Path(file_okay=False), help='Directory path to save the results', default=os.path.join(os.getcwd(), 'out', 'discriminator_synthesis'), show_default=True, metavar='DIR')
 @click.option('--description', '-desc', type=str, help='Additional description name for the directory path to save results', default='', show_default=True)
@@ -551,6 +561,7 @@ def discriminator_dream(
         num_octaves: int,
         octave_scale: float,
         unzoom_octave: bool,
+        batch_size: int,
         outdir: Union[str, os.PathLike],
         description: str,
 ):
@@ -639,28 +650,46 @@ def discriminator_dream(
         desc = f'{desc}-{description}' if len(description) != 0 else desc
         run_dir = gen_utils.make_run_dir(outdir, desc)
 
+        if batch_size > 1 and {'b4_mbstd', 'b4_conv', 'fc', 'out'}.intersection(layers):
+            print('Note: layers past b4_mbstd use minibatch statistics, so results with --batch-size > 1 '
+                  'will differ slightly from running one seed at a time.')
+
         starting_images, used_seeds = [], []
-        for seed in seeds:
-            # Get the image and image name
-            image, starting_image = get_image(seed=seed, image_noise=image_noise,
-                                              starting_image=starting_image,
-                                              image_size=model_resolution,
-                                              convert_to_grayscale=convert_to_grayscale)
+        for chunk_start in range(0, len(seeds), batch_size):
+            chunk_seeds = seeds[chunk_start:chunk_start + batch_size]
 
-            # Extract deep dream image
-            dreamed_image = deep_dream(image, model, model_resolution, layers=layers, channels=channels, seed=seed, normed=norm_model_layers,
-                                       sqrt_normed=sqrt_norm_model_layers, iterations=iterations, lr=learning_rate,
-                                       octave_scale=octave_scale, num_octaves=num_octaves, unzoom_octave=unzoom_octave)
+            # Get the images and image names for this batch of seeds
+            images, image_names = [], []
+            for seed in chunk_seeds:
+                image, starting_image = get_image(seed=seed, image_noise=image_noise,
+                                                  starting_image=starting_image,
+                                                  image_size=model_resolution,
+                                                  convert_to_grayscale=convert_to_grayscale)
+                images.append(image)
+                image_names.append(starting_image)
+                starting_image = None
 
-            # For logging later
-            starting_images.append(starting_image)
-            used_seeds.append(seed)
+            # Extract deep dream images, the whole batch in one pass (get_image already returns
+            # model_resolution squares, so the initial crop/resize transform is a no-op)
+            batch = torch.stack([preprocess(image) for image in images])
+            dreamed_images = deep_dream(batch, model, model_resolution, layers=layers, channels=channels,
+                                        seed=chunk_seeds[0] if len(chunk_seeds) == 1 else chunk_seeds,
+                                        normed=norm_model_layers, sqrt_normed=sqrt_norm_model_layers,
+                                        iterations=iterations, lr=learning_rate, octave_scale=octave_scale,
+                                        num_octaves=num_octaves, unzoom_octave=unzoom_octave,
+                                        ignore_initial_transform=True)
+            if dreamed_images.ndim == 3:
+                dreamed_images = dreamed_images[None]
 
-            # Save the resulting image and initial image
-            filename = f'dreamed_{os.path.basename(starting_image)}'
-            Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
-            image.save(os.path.join(run_dir, os.path.basename(starting_image)))
-            starting_image = None
+            for image, image_name, seed, dreamed_image in zip(images, image_names, chunk_seeds, dreamed_images):
+                # For logging later
+                starting_images.append(image_name)
+                used_seeds.append(seed)
+
+                # Save the resulting image and initial image
+                filename = f'dreamed_{os.path.basename(image_name)}'
+                Image.fromarray(dreamed_image).save(os.path.join(run_dir, filename))
+                image.save(os.path.join(run_dir, os.path.basename(image_name)))
 
         # Save the configuration used
         ctx.obj = {
@@ -680,6 +709,8 @@ def discriminator_dream(
                 'octave_scale': octave_scale,
                 'num_octaves': num_octaves,
                 'unzoom_octave': unzoom_octave},
+            'performance_options': {
+                'batch_size': batch_size},
             'extra_parameters': {
                 'outdir': run_dir,
                 'description': description}
@@ -1203,6 +1234,74 @@ def random_interpolation(
 # ----------------------------------------------------------------------------
 
 
+def _slice_volume(volume: np.ndarray, axis: str) -> np.ndarray:
+    """Reorder a (T, H, W, C) volume so the first dimension indexes slices perpendicular to `axis`"""
+    if axis == 't':
+        return volume                          # (T, H, W, C): xy planes
+    elif axis == 'y':
+        return volume.transpose(1, 0, 2, 3)    # (H, T, W, C): tx planes
+    return volume.transpose(2, 0, 1, 3)        # (W, T, H, C): ty planes
+
+
+def _dream_video_worker(rank: int, num_gpus: int, volume_path: str, run_dir: str, opts: dict) -> None:
+    """
+    Worker for (multi-GPU) dream-video generation. Worker `rank` loads the Discriminator on
+    GPU `rank`, memory-maps the shared noise volume, and dreams the slice indices
+    rank, rank + num_gpus, rank + 2*num_gpus, ... of every requested axis, `batch_size`
+    slices per forward pass. Frames are named by their global slice index, so the parent
+    can assemble the videos once all workers have finished.
+    """
+    device = torch.device('cuda', rank) if torch.cuda.is_available() else torch.device('cpu')
+    if device.type == 'cuda':
+        torch.cuda.set_device(device)
+
+    D = gen_utils.load_network('D', opts['network_pkl'], opts['cfg'], device)
+    model = DiscriminatorFeatures(D).requires_grad_(False).to(device)
+
+    # Memory-map the volume so each worker only reads the slices it needs
+    volume = np.load(volume_path, mmap_mode='r')
+    batch_size = opts['batch_size']
+
+    for axis in opts['axes']:
+        slices = _slice_volume(volume, axis)
+        axis_dir = os.path.join(run_dir, f'axis_{axis}')
+        n_digits = int(np.log10(len(slices))) + 1
+        indices = list(range(rank, len(slices), num_gpus))
+
+        pbar = tqdm(total=len(indices), desc=f'GPU {rank}: dreaming along the {axis}-axis',
+                    unit='frame', position=rank)
+        for start in range(0, len(indices), batch_size):
+            batch_indices = indices[start:start + batch_size]
+            # Preprocess each slice and tile it up to a Discriminator-friendly size
+            # (np.array copies the slice out of the read-only memory map)
+            tensors = []
+            for i in batch_indices:
+                slice_tensor = preprocess(np.array(slices[i]))
+                slice_tensor, (h, w) = pad_to_multiple(slice_tensor, opts['multiple'])
+                tensors.append(slice_tensor)
+            batch = torch.stack(tensors)
+
+            dreamed = deep_dream(
+                batch, model, opts['model_resolution'],
+                layers=opts['layers'], channels=opts['channels'], seed=None,
+                normed=opts['norm_model_layers'], sqrt_normed=opts['sqrt_norm_model_layers'],
+                iterations=opts['iterations'], lr=opts['learning_rate'],
+                octave_scale=opts['octave_scale'], num_octaves=opts['num_octaves'],
+                unzoom_octave=opts['unzoom_octave'],
+                disable_inner_tqdm=True,
+                ignore_initial_transform=True
+            )
+            if dreamed.ndim == 3:
+                dreamed = dreamed[None]
+
+            for j, i in enumerate(batch_indices):
+                # Crop back to the slice size (made even, as yuv420p requires even dimensions)
+                frame = dreamed[j][:h - h % 2, :w - w % 2]
+                Image.fromarray(frame).save(os.path.join(axis_dir, f'frame_{i:0{n_digits}d}.jpg'))
+            pbar.update(len(batch_indices))
+        pbar.close()
+
+
 def combine_axis_videos(video_paths: List[Union[str, os.PathLike]],
                         out_path: Union[str, os.PathLike],
                         height: int = 512) -> None:
@@ -1239,6 +1338,9 @@ def combine_axis_videos(video_paths: List[Union[str, os.PathLike]],
 @click.option('--img-size', type=click.IntRange(min=8), help='Size of the noise volume along the y and x axes (None = Discriminator resolution)', default=None)
 @click.option('--noise-octaves', type=click.IntRange(min=1), help='Number of fractal octaves for the Perlin noise', default=6, show_default=True)
 @click.option('--loop', is_flag=True, help='Make the noise periodic in time, so the t-axis video loops seamlessly')
+# Performance options
+@click.option('--gpus', type=click.IntRange(min=1), help='Number of GPUs to split the slices across (1 process per GPU)', default=1, show_default=True)
+@click.option('--batch-size', type=click.IntRange(min=1), help='Number of slices to dream per forward pass on each GPU', default=1, show_default=True)
 # Video options
 @click.option('--fps', type=gen_utils.parse_fps, help='FPS for the output videos', default=25, show_default=True)
 @click.option('--combine', type=bool, help='Stack the axis videos side by side into a single comparison video', default=True, show_default=True)
@@ -1267,6 +1369,8 @@ def discriminator_dream_video(
         img_size: Optional[int],
         noise_octaves: int,
         loop: bool,
+        gpus: int,
+        batch_size: int,
         fps: int,
         combine: bool,
         display_height: int,
@@ -1284,13 +1388,25 @@ def discriminator_dream_video(
 
     Non-square slices are tiled up to a Discriminator-friendly size, dreamed, and
     cropped back, so the volume dimensions do not need to match the model resolution.
-    """
-    device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
 
-    # Load Discriminator
-    D = gen_utils.load_network('D', network_pkl, cfg, device)
+    Slices are independent of each other, so the work can be split across GPUs
+    (--gpus N spawns one worker process per GPU) and batched (--batch-size B dreams
+    B slices per forward pass); both are exactly equivalent to the sequential result,
+    except for layers past b4_mbstd, whose minibatch statistics depend on the batch.
+    """
+    # Number of worker processes/GPUs
+    if torch.cuda.is_available():
+        available_gpus = torch.cuda.device_count()
+        if gpus > available_gpus:
+            print(f'Requested {gpus} GPUs, but only {available_gpus} are visible; using {available_gpus}.')
+        num_gpus = min(gpus, available_gpus)
+    else:
+        num_gpus = 1
+
+    # Load the Discriminator on the CPU just to get its resolution; the workers load it on their own GPUs
+    D = gen_utils.load_network('D', network_pkl, cfg, torch.device('cpu'))
     model_resolution = D.img_resolution
-    model = DiscriminatorFeatures(D).requires_grad_(False).to(device)
+    del D
 
     # Parse layers
     layers = layers.split(',')
@@ -1300,6 +1416,10 @@ def discriminator_dream_video(
         available_layers = get_available_layers(max_resolution=model_resolution)
         layers = [layer for layer in layers if layer in available_layers]
     assert len(layers) > 0, f'No valid layers given! Available layers: {get_available_layers(model_resolution)}'
+
+    if batch_size > 1 and {'b4_mbstd', 'b4_conv', 'fc', 'out'}.intersection(layers):
+        print('Note: layers past b4_mbstd use minibatch statistics, so results with --batch-size > 1 '
+              'will differ slightly from running one slice at a time.')
 
     # Parse axes
     axes = [axis.strip() for axis in axes.split(',') if axis.strip()]
@@ -1314,45 +1434,50 @@ def discriminator_dream_video(
     desc = f'discriminator-dream-video-axes_{"-".join(axes)}'
     desc = f'{desc}-{description}' if description else desc
     run_dir = gen_utils.make_run_dir(outdir, desc)
+    for axis in axes:
+        os.makedirs(os.path.join(run_dir, f'axis_{axis}'), exist_ok=True)
 
+    # Generate the noise volume once and share it with the workers via a memory-mapped file
     print(f'Generating a ({num_frames}, {img_size}, {img_size}) 3D Perlin noise volume...')
-    volume = get_perlin_volume(seed, num_frames, img_size, convert_to_grayscale, device, loop, noise_octaves)
+    noise_device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+    volume = get_perlin_volume(seed, num_frames, img_size, convert_to_grayscale, noise_device, loop, noise_octaves)
+    volume_path = os.path.join(run_dir, 'perlin_volume.npy')
+    np.save(volume_path, volume)
+    del volume
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
+    worker_opts = {
+        'network_pkl': network_pkl,
+        'cfg': cfg,
+        'model_resolution': model_resolution,
+        'layers': layers,
+        'channels': channels,
+        'norm_model_layers': norm_model_layers,
+        'sqrt_norm_model_layers': sqrt_norm_model_layers,
+        'iterations': iterations,
+        'learning_rate': learning_rate,
+        'octave_scale': octave_scale,
+        'num_octaves': num_octaves,
+        'unzoom_octave': unzoom_octave,
+        'axes': axes,
+        'multiple': multiple,
+        'batch_size': batch_size,
+    }
+
+    if num_gpus > 1:
+        print(f'Splitting the slices across {num_gpus} GPUs ({batch_size} slice(s) per forward pass each)...')
+        torch.multiprocessing.spawn(_dream_video_worker, args=(num_gpus, volume_path, run_dir, worker_opts),
+                                    nprocs=num_gpus, join=True)
+    else:
+        _dream_video_worker(0, 1, volume_path, run_dir, worker_opts)
+
+    # Assemble one video per axis from the saved frames
     axis_videos = []
     for axis in axes:
-        # Slice the volume perpendicular to the chosen axis; first dim indexes the slices
-        if axis == 't':
-            slices = volume                              # (T, H, W, C): xy planes
-        elif axis == 'y':
-            slices = volume.transpose(1, 0, 2, 3)        # (H, T, W, C): tx planes
-        else:
-            slices = volume.transpose(2, 0, 1, 3)        # (W, T, H, C): ty planes
-
+        num_slices = num_frames if axis == 't' else img_size
+        n_digits = int(np.log10(num_slices)) + 1
         axis_dir = os.path.join(run_dir, f'axis_{axis}')
-        os.makedirs(axis_dir, exist_ok=True)
-        n_digits = int(np.log10(len(slices))) + 1
-
-        for idx, slice_np in enumerate(tqdm(slices, desc=f'Dreaming along the {axis}-axis', unit='frame')):
-            # Preprocess the slice and tile it up to a Discriminator-friendly size
-            slice_tensor = preprocess(np.ascontiguousarray(slice_np))
-            slice_tensor, (h, w) = pad_to_multiple(slice_tensor, multiple)
-
-            dreamed_frame = deep_dream(
-                slice_tensor, model, model_resolution,
-                layers=layers, channels=channels, seed=None,
-                normed=norm_model_layers, sqrt_normed=sqrt_norm_model_layers,
-                iterations=iterations, lr=learning_rate,
-                octave_scale=octave_scale, num_octaves=num_octaves,
-                unzoom_octave=unzoom_octave,
-                disable_inner_tqdm=True,
-                ignore_initial_transform=True
-            )
-
-            # Crop back to the slice size (made even, as yuv420p requires even dimensions)
-            dreamed_frame = dreamed_frame[:h - h % 2, :w - w % 2]
-            filename = f'frame_{idx:0{n_digits}d}.jpg'
-            Image.fromarray(dreamed_frame).save(os.path.join(axis_dir, filename))
-
         gen_utils.save_video_from_images(run_dir=axis_dir, image_names=f'frame_%0{n_digits}d.jpg',
                                          video_name=f'dream-video-{axis}_axis', fps=fps, reverse_video=False)
         axis_videos.append(os.path.join(axis_dir, f'dream-video-{axis}_axis.mp4'))
@@ -1392,6 +1517,10 @@ def discriminator_dream_video(
             'fps': fps,
             'combine': combine,
             'display_height': display_height
+        },
+        'performance_options': {
+            'gpus': num_gpus,
+            'batch_size': batch_size
         },
         'extra_parameters': {
             'outdir': run_dir,

--- a/fractalperlin.py
+++ b/fractalperlin.py
@@ -83,149 +83,87 @@ class FractalPerlin3D(object):
     """
     3D Fractal Perlin Noise generator for smooth video sequences.
 
-    Generates coherent noise across time, perfect for DeepDream-style video synthesis.
-    Each frame is a slice of 3D noise at a specific time coordinate.
+    Proper lattice-based Perlin noise: each octave places random unit gradient
+    vectors on a coarse (t, y, x) lattice and interpolates their dot products
+    with the local offset vectors using the smoothstep fade. Summing octaves
+    with decreasing amplitudes gives the fractal (fBm) result.
+
+    The resulting volume is isotropic, so it can be sliced along any of the
+    three axes (xy, ty, tx planes) and still look like 2D Perlin noise.
 
     Args:
-        shape: Tuple of (channels, height, width) - spatial dimensions
-        resolutions: List of (time_res, height_res, width_res) tuples for each octave
+        shape: Tuple of (channels, height, width); each channel gets an independent noise field
+        resolutions: List of (t_cells, y_cells, x_cells) lattice cells per octave
         factors: List of amplitude factors for each octave
         num_frames: Total number of frames to generate
         generator: PyTorch random generator (for reproducibility)
-        loop: If True, the noise will loop seamlessly
+        loop: If True, the noise is periodic along the time axis (seamless loop)
     """
 
     def __init__(self, shape: Tuple[int, int, int], resolutions: List[Tuple[int, int, int]],
                  factors: List[float], num_frames: int,
                  generator=torch.random.default_generator, loop: bool = True):
-        self.shape = shape if len(shape) == 3 else (None,) + shape  # (C, H, W)
+        shape = shape if len(shape) == 3 else (1,) + tuple(shape)
+        self.channels, self.height, self.width = shape
         self.factors = factors
         self.num_frames = num_frames
         self.generator = generator
         self.device = generator.device
-        self.resolutions = resolutions  # [(t_res, h_res, w_res), ...]
+        self.resolutions = resolutions  # [(t_cells, y_cells, x_cells), ...]
         self.loop = loop
 
-        # Grid shapes for each octave
-        self.grid_shapes = [
-            (num_frames // res[0] if loop else num_frames,
-             shape[1] // res[1],
-             shape[2] // res[2])
-            for res in resolutions
-        ]
-
-        # Precompute interpolation grids for each octave
-        self.setup_interpolation_grids()
-
-    def setup_interpolation_grids(self):
-        """Precompute interpolation grids for efficient noise generation."""
-        self.lint_grids = []
-        self.liny_grids = []
-        self.linx_grids = []
-        self.masks = []
-
-        for octave, (tres, hres, wres) in enumerate(self.resolutions):
-            gs = self.grid_shapes[octave]
-
-            # Create 1D interpolation vectors
-            if self.loop:
-                # For looping, we tile the time dimension
-                lint = torch.linspace(0, 1, tres, device=self.device)
-                lint = lint.repeat(self.num_frames // tres + 1)[:self.num_frames]
-            else:
-                lint = torch.linspace(0, 1, gs[0], device=self.device)
-
-            liny = torch.linspace(0, 1, gs[1], device=self.device)
-            linx = torch.linspace(0, 1, gs[2], device=self.device)
-
-            self.lint_grids.append(lint)
-            self.liny_grids.append(liny)
-            self.linx_grids.append(linx)
-
-            # Compute 3D fade masks (8 corners of cube)
-            fade_t = self.fade(lint)[:, None, None]
-            fade_y = self.fade(liny)[None, :, None]
-            fade_x = self.fade(linx)[None, None, :]
-
-            # 8 corner masks for trilinear interpolation
-            masks_octave = []
-            for dt in [fade_t, 1 - fade_t]:
-                for dy in [fade_y, 1 - fade_y]:
-                    for dx in [fade_x, 1 - fade_x]:
-                        masks_octave.append(dt * dy * dx)
-            self.masks.append(masks_octave)
-
-    def fade(self, t: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    def fade(t: torch.Tensor) -> torch.Tensor:
         """Smoothstep fade function: 6t^5 - 15t^4 + 10t^3"""
         return 6 * t**5 - 15 * t**4 + 10 * t**3
 
     def perlin_noise_3d(self, octave: int) -> torch.Tensor:
-        """Generate 3D Perlin noise for a specific octave."""
-        tres, hres, wres = self.resolutions[octave]
+        """Generate one octave of 3D Perlin noise; returns a (num_frames, H, W) tensor."""
+        T, H, W = self.num_frames, self.height, self.width
+        ct, cy, cx = self.resolutions[octave]
+        device = self.device
 
-        # Generate random gradient vectors for each grid point
-        # We need (tres+2) x (hres+2) x (wres+2) grid points
-        grid_size = (tres + 2, hres + 2, wres + 2)
+        # Random unit gradient vectors on the (ct+1, cy+1, cx+1) lattice (uniform on the sphere)
+        g_shape = (ct + 1, cy + 1, cx + 1)
+        theta = torch.rand(g_shape, generator=self.generator, device=device) * tau
+        gt = torch.rand(g_shape, generator=self.generator, device=device) * 2 - 1
+        s = torch.sqrt(torch.clamp(1 - gt**2, min=0.0))
+        grads = torch.stack((s * torch.cos(theta), s * torch.sin(theta), gt), dim=-1)  # (..., [gx, gy, gt])
+        if self.loop:
+            grads[-1] = grads[0]  # Periodic along time => seamless loop
 
-        # Random angles for gradient vectors (simplified 3D gradients)
-        theta = torch.zeros(grid_size, device=self.device).uniform_(0, tau, generator=self.generator)
-        phi = torch.zeros(grid_size, device=self.device).uniform_(0, np.pi, generator=self.generator)
+        # Voxel coordinates in lattice space: cell index + fractional position
+        tc = torch.arange(T, device=device, dtype=torch.float32) * (ct / T)
+        yc = torch.arange(H, device=device, dtype=torch.float32) * (cy / H)
+        xc = torch.arange(W, device=device, dtype=torch.float32) * (cx / W)
+        y0 = yc.long().clamp_(max=cy - 1)
+        x0 = xc.long().clamp_(max=cx - 1)
+        fy = (yc - y0).view(1, H, 1)
+        fx = (xc - x0).view(1, 1, W)
+        wy, wx = self.fade(fy), self.fade(fx)
 
-        # Convert spherical to Cartesian coordinates
-        grad_x = torch.sin(phi) * torch.cos(theta)
-        grad_y = torch.sin(phi) * torch.sin(theta)
-        grad_z = torch.cos(phi)
-
-        # Interpolation grid positions
-        lint = self.lint_grids[octave]
-        liny = self.liny_grids[octave]
-        linx = self.linx_grids[octave]
-
-        # Create distance vectors for each corner
-        # This is a simplified implementation - full 3D Perlin is more complex
-        # but this gives us smooth, coherent noise across time
-
-        # Generate gradients at corners
-        gradients = []
-        for t_idx in range(2):
-            for y_idx in range(2):
-                for x_idx in range(2):
-                    gx = grad_x[t_idx:t_idx+tres, y_idx:y_idx+hres, x_idx:x_idx+wres]
-                    gy = grad_y[t_idx:t_idx+tres, y_idx:y_idx+hres, x_idx:x_idx+wres]
-                    gz = grad_z[t_idx:t_idx+tres, y_idx:y_idx+hres, x_idx:x_idx+wres]
-
-                    # Dot product with distance vectors
-                    if t_idx == 0:
-                        dt = lint[:, None, None]
-                    else:
-                        dt = lint[:, None, None] - 1
-
-                    if y_idx == 0:
-                        dy = liny[None, :, None]
-                    else:
-                        dy = liny[None, :, None] - 1
-
-                    if x_idx == 0:
-                        dx = linx[None, None, :]
-                    else:
-                        dx = linx[None, None, :] - 1
-
-                    # Ensure proper broadcasting
-                    gx_exp = gx[:lint.shape[0], :liny.shape[0], :linx.shape[0]]
-                    gy_exp = gy[:lint.shape[0], :liny.shape[0], :linx.shape[0]]
-                    gz_exp = gz[:lint.shape[0], :liny.shape[0], :linx.shape[0]]
-
-                    dot = gx_exp * dx + gy_exp * dy + gz_exp * dt
-                    gradients.append(dot)
-
-        # Trilinear interpolation using precomputed masks
-        noise = torch.zeros((self.num_frames, self.shape[1], self.shape[2]), device=self.device)
-        for mask, gradient in zip(self.masks[octave], gradients):
-            # Crop gradient to match noise dimensions
-            grad_crop = gradient[:self.num_frames, :self.shape[1], :self.shape[2]]
-            mask_crop = mask[:self.num_frames, :self.shape[1], :self.shape[2]]
-            noise += mask_crop * grad_crop
-
+        noise = torch.empty((T, H, W), device=device)
+        # Chunk along time to bound the memory of the (chunk, H, W, 3) gradient gathers
+        chunk = max(1, 2**22 // (H * W))
+        for start in range(0, T, chunk):
+            ts = tc[start:start + chunk]
+            t0 = ts.long().clamp_(max=ct - 1)
+            ft = (ts - t0).view(-1, 1, 1)
+            wt = self.fade(ft)
+            acc = torch.zeros((len(ts), H, W), device=device)
+            # Trilinear interpolation of the 8 corner gradient dot products
+            for dt in (0, 1):
+                w_t = wt if dt else 1 - wt
+                idx_t = (t0 + dt).view(-1, 1, 1)
+                for dy in (0, 1):
+                    w_ty = w_t * (wy if dy else 1 - wy)
+                    idx_y = (y0 + dy).view(1, -1, 1)
+                    for dx in (0, 1):
+                        weight = w_ty * (wx if dx else 1 - wx)
+                        g = grads[idx_t, idx_y, (x0 + dx).view(1, 1, -1)]  # (chunk, H, W, 3)
+                        dot = g[..., 0] * (fx - dx) + g[..., 1] * (fy - dy) + g[..., 2] * (ft - dt)
+                        acc += weight * dot
+            noise[start:start + chunk] = acc
         return noise
 
     def __call__(self) -> torch.Tensor:
@@ -233,23 +171,16 @@ class FractalPerlin3D(object):
         Generate 3D fractal Perlin noise.
 
         Returns:
-            Tensor of shape (num_frames, C, H, W) - a video sequence
+            Tensor of shape (num_frames, C, H, W) - a video sequence,
+            with an independent noise field per channel
         """
-        # Initialize with zeros
-        noise = torch.zeros((self.num_frames, self.shape[1], self.shape[2]), device=self.device)
-
-        # Sum octaves with their respective factors
-        for octave, factor in enumerate(self.factors):
-            noise += factor * self.perlin_noise_3d(octave)
-
-        # Expand to include channel dimension if needed
-        if self.shape[0] is not None and self.shape[0] > 1:
-            # Replicate for each channel (RGB)
-            noise = noise.unsqueeze(1).expand(-1, self.shape[0], -1, -1)
-        else:
-            noise = noise.unsqueeze(1)
-
-        return noise  # (num_frames, C, H, W)
+        channels = []
+        for _ in range(self.channels):
+            noise = torch.zeros((self.num_frames, self.height, self.width), device=self.device)
+            for octave, factor in enumerate(self.factors):
+                noise += factor * self.perlin_noise_3d(octave)
+            channels.append(noise)
+        return torch.stack(channels, dim=1)  # (num_frames, C, H, W)
 
 
 # Convenience functions
@@ -260,45 +191,58 @@ def get_2d_perlin(shape: Tuple[int, int, int], seed: int = 0,
     Generate 2D fractal Perlin noise with default parameters.
 
     Args:
-        shape: (C, H, W) tuple
+        shape: (C, H, W) tuple; each channel gets an independent noise field
         seed: Random seed
         device: Device to generate on ('cuda' or 'cpu')
-        lacunarity: Frequency multiplier between octaves (default 2.0)
+        lacunarity: Frequency multiplier between octaves (currently fixed at 2.0,
+                    as FractalPerlin2D requires H and W to be divisible by the cell counts)
         persistence: Amplitude multiplier between octaves (default 0.5)
-        octaves: Number of octaves to sum
+        octaves: Number of octaves to sum (clamped so the finest lattice fits the image)
 
     Returns:
-        Tensor of shape (1, C, H, W) with values in range [-1, 1]
+        Tensor of shape (C, H, W) with values approximately in [-1, 1]
     """
+    # The finest lattice (2**octaves cells) must divide the image size
+    octaves = min(octaves, int(np.log2(min(shape[1], shape[2]))))
     resolutions = [(2**i, 2**i) for i in range(1, octaves + 1)]
     factors = [persistence**i for i in range(octaves)]
     g = torch.Generator(device=device).manual_seed(seed)
-    noise = FractalPerlin2D(shape, resolutions, factors, generator=g)(batch_size=1)
+    noise = FractalPerlin2D(shape, resolutions, factors, generator=g)()  # batch dim = channels
     return noise
 
 
 def get_3d_perlin(shape: Tuple[int, int, int], num_frames: int, seed: int = 0,
                   device: str = 'cuda', lacunarity: float = 2.0,
                   persistence: float = 0.5, octaves: int = 6,
-                  loop: bool = True) -> torch.Tensor:
+                  loop: bool = True, isotropic: bool = True) -> torch.Tensor:
     """
     Generate 3D fractal Perlin noise for video sequences.
 
     Args:
-        shape: (C, H, W) tuple for spatial dimensions
+        shape: (C, H, W) tuple for spatial dimensions; each channel is an independent field
         num_frames: Number of frames to generate
         seed: Random seed
         device: Device to generate on ('cuda' or 'cpu')
         lacunarity: Frequency multiplier between octaves (default 2.0)
         persistence: Amplitude multiplier between octaves (default 0.5)
         octaves: Number of octaves to sum
-        loop: If True, the video will loop seamlessly
+        loop: If True, the video will loop seamlessly (periodic along time)
+        isotropic: If True, scale the time-axis cell count by num_frames / max(H, W),
+                   so a lattice cell spans the same "world distance" along every axis;
+                   this makes slices along t, y, and x statistically equivalent
 
     Returns:
-        Tensor of shape (num_frames, C, H, W) with values in range [-1, 1]
+        Tensor of shape (num_frames, C, H, W) with values approximately in [-1, 1]
     """
-    # Resolutions include time dimension
-    resolutions = [(2**i, 2**i, 2**i) for i in range(1, octaves + 1)]
+    T = num_frames
+    S = max(shape[1], shape[2])
+    resolutions = []
+    for i in range(octaves):
+        cells = 2 * lacunarity**i
+        cy = max(1, min(round(cells), shape[1]))
+        cx = max(1, min(round(cells), shape[2]))
+        ct = max(1, round(cells * T / S)) if isotropic else max(1, min(round(cells), T))
+        resolutions.append((ct, cy, cx))
     factors = [persistence**i for i in range(octaves)]
     g = torch.Generator(device=device).manual_seed(seed)
     noise = FractalPerlin3D(shape, resolutions, factors, num_frames, generator=g, loop=loop)()

--- a/network_features.py
+++ b/network_features.py
@@ -63,7 +63,7 @@ def extract_layer_features(features_dict: OrderedDict, layers: List[str],
         if channels is not None:
             max_channels = feats.shape[1]
             valid_channels = [c for c in channels if 0 <= c < max_channels]
-            valid_channels = list(set(valid_channels))  # Remove duplicates
+            valid_channels = sorted(set(valid_channels))  # Remove duplicates, keep deterministic order
 
             if valid_channels:
                 if feats.dim() == 4:  # Conv layers: [B, C, H, W]
@@ -267,6 +267,12 @@ class DiscriminatorFeatures(nn.Module):
         """
         Extract features from specified discriminator layers.
 
+        The forward pass stops as soon as all requested layers have been computed,
+        so asking for shallow layers (e.g. 'b64_conv0') is much cheaper than running
+        the whole Discriminator. The input can be of any spatial size, as long as
+        both dimensions remain divisible by 2 for every downsampling step needed to
+        reach the deepest requested layer (pad the input if necessary).
+
         Args:
             x: Input image tensor [B, 3, H, W]
             layers: List of layer names (None = ['out'])
@@ -275,12 +281,13 @@ class DiscriminatorFeatures(nn.Module):
             sqrt_normed: If True, divide by sqrt of number of elements
 
         Returns:
-            Tuple of feature tensors
+            Tuple of feature tensors, in the same order as the requested layers
 
         Available layers:
             - 'from_rgb': Initial RGB conversion
             - 'b{res}_conv0', 'b{res}_conv1': Convolution layers at each resolution
-            - 'b{res}_skip': Skip connections
+              ('b{res}_conv1' is the block output, i.e., conv1 plus the skip branch)
+            - 'b{res}_skip': Skip branch alone (before the residual addition)
             - 'b4_mbstd', 'b4_conv': Final block
             - 'fc', 'out': Fully connected and output layers
         """
@@ -289,26 +296,39 @@ class DiscriminatorFeatures(nn.Module):
         layers = layers if layers is not None else ['out']
         norm_mode = 'numel' if normed else ('sqrt' if sqrt_normed else 'none')
 
-        # Build features dictionary
+        remaining = set(layers)
         features = OrderedDict()
-        features['from_rgb'] = getattr(self, 'from_rgb')(x)
 
-        # Process each resolution block
-        for idx, res in enumerate(self.block_resolutions):
-            prev_layer = 'from_rgb' if idx == 0 else f'b{self.block_resolutions[idx-1]}_conv1'
+        def store(name: str, value: torch.Tensor) -> None:
+            if name in remaining:
+                features[name] = value
+                remaining.discard(name)
 
-            features[f'b{res}_skip'] = getattr(self, f'b{res}_skip')(features[prev_layer], gain=np.sqrt(0.5))
-            features[f'b{res}_conv0'] = getattr(self, f'b{res}_conv0')(features[prev_layer])
-            features[f'b{res}_conv1'] = getattr(self, f'b{res}_conv1')(features[f'b{res}_conv0'], gain=np.sqrt(0.5))
+        y = self.from_rgb(x)
+        store('from_rgb', y)
 
-            # Skip connection addition (in-place)
-            features[f'b{res}_conv1'] = features[f'b{res}_skip'].add_(features[f'b{res}_conv1'])
+        # Process each resolution block, stopping early once all requested layers are computed
+        for res in self.block_resolutions:
+            if not remaining:
+                break
+            skip = getattr(self, f'b{res}_skip')(y, gain=np.sqrt(0.5))
+            store(f'b{res}_skip', skip)
+            conv0 = getattr(self, f'b{res}_conv0')(y)
+            store(f'b{res}_conv0', conv0)
+            y = skip + getattr(self, f'b{res}_conv1')(conv0, gain=np.sqrt(0.5))
+            store(f'b{res}_conv1', y)
 
-        # Final block (always at 8x8 → 4x4)
-        features['b4_mbstd'] = self.b4_mbstd(features['b8_conv1'])
-        features['b4_conv'] = self.b4_conv(features['b4_mbstd'])
-        features['b4_conv'] = self.adavgpool(features['b4_conv'])
-        features['fc'] = self.fc(features['b4_conv'].flatten(1))
-        features['out'] = self.out(features['fc'])
+        # Final block (4x4); only computed if any of its layers were requested
+        if remaining:
+            mbstd = self.b4_mbstd(y)
+            store('b4_mbstd', mbstd)
+            b4_conv = self.adavgpool(self.b4_conv(mbstd))
+            store('b4_conv', b4_conv)
+            fc = self.fc(b4_conv.flatten(1))
+            store('fc', fc)
+            store('out', self.out(fc))
+
+        if remaining:
+            raise ValueError(f'Unknown Discriminator layer(s): {sorted(remaining)}')
 
         return tuple(extract_layer_features(features, layers, channels, norm_mode))

--- a/torch_utils/custom_ops.py
+++ b/torch_utils/custom_ops.py
@@ -24,6 +24,14 @@ from torch.utils.file_baton import FileBaton
 verbosity = 'brief' # Verbosity level: 'none', 'brief', 'full'
 
 #----------------------------------------------------------------------------
+
+def use_ref_ops():
+    """Escape hatch: set STYLEGAN3_USE_REF_OPS=1 to skip compiling the custom
+    CUDA plugins altogether and use the reference (pure PyTorch) implementations.
+    Slower, but requires no CUDA toolkit/compiler on the machine."""
+    return os.environ.get('STYLEGAN3_USE_REF_OPS', '').lower() in ('1', 'true', 'yes', 'on')
+
+#----------------------------------------------------------------------------
 # Internal helper funcs.
 
 def _find_compiler_bindir():

--- a/torch_utils/ops/bias_act.py
+++ b/torch_utils/ops/bias_act.py
@@ -9,6 +9,7 @@
 """Custom PyTorch ops for efficient bias and activation."""
 
 import os
+import warnings
 import numpy as np
 import torch
 import dnnlib
@@ -38,14 +39,23 @@ _null_tensor = torch.empty([0])
 def _init():
     global _plugin
     if _plugin is None:
-        _plugin = custom_ops.get_plugin(
-            module_name='bias_act_plugin',
-            sources=['bias_act.cpp', 'bias_act.cu'],
-            headers=['bias_act.h'],
-            source_dir=os.path.dirname(__file__),
-            extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
-        )
-    return True
+        if custom_ops.use_ref_ops():
+            _plugin = False
+        else:
+            try:
+                _plugin = custom_ops.get_plugin(
+                    module_name='bias_act_plugin',
+                    sources=['bias_act.cpp', 'bias_act.cu'],
+                    headers=['bias_act.h'],
+                    source_dir=os.path.dirname(__file__),
+                    extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
+                )
+            except Exception as e:
+                _plugin = False
+                warnings.warn('Failed to build the bias_act CUDA plugin; falling back to the (slower) reference '
+                              'PyTorch implementation. Check CUDA_HOME points to a full CUDA toolkit, or set '
+                              f'STYLEGAN3_USE_REF_OPS=1 to silence this warning. Build error:\n{e}')
+    return _plugin is not False
 
 #----------------------------------------------------------------------------
 

--- a/torch_utils/ops/filtered_lrelu.py
+++ b/torch_utils/ops/filtered_lrelu.py
@@ -27,15 +27,24 @@ def _init():
     if os.name == 'nt':
         extras['extra_cflags'] = ['/std:c++17']
     if _plugin is None:
-        _plugin = custom_ops.get_plugin(
-            module_name='filtered_lrelu_plugin',
-            sources=['filtered_lrelu.cpp', 'filtered_lrelu_wr.cu', 'filtered_lrelu_rd.cu', 'filtered_lrelu_ns.cu'],
-            headers=['filtered_lrelu.h', 'filtered_lrelu.cu'],
-            source_dir=os.path.dirname(__file__),
-            extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
-            **extras,
-        )
-    return True
+        if custom_ops.use_ref_ops():
+            _plugin = False
+        else:
+            try:
+                _plugin = custom_ops.get_plugin(
+                    module_name='filtered_lrelu_plugin',
+                    sources=['filtered_lrelu.cpp', 'filtered_lrelu_wr.cu', 'filtered_lrelu_rd.cu', 'filtered_lrelu_ns.cu'],
+                    headers=['filtered_lrelu.h', 'filtered_lrelu.cu'],
+                    source_dir=os.path.dirname(__file__),
+                    extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
+                    **extras,
+                )
+            except Exception as e:
+                _plugin = False
+                warnings.warn('Failed to build the filtered_lrelu CUDA plugin; falling back to the (slower) reference '
+                              'PyTorch implementation. Check CUDA_HOME points to a full CUDA toolkit, or set '
+                              f'STYLEGAN3_USE_REF_OPS=1 to silence this warning. Build error:\n{e}')
+    return _plugin is not False
 
 def _get_filter_size(f):
     if f is None:

--- a/torch_utils/ops/upfirdn2d.py
+++ b/torch_utils/ops/upfirdn2d.py
@@ -9,6 +9,7 @@
 """Custom PyTorch ops for efficient resampling of 2D images."""
 
 import os
+import warnings
 import numpy as np
 import torch
 
@@ -23,14 +24,23 @@ _plugin = None
 def _init():
     global _plugin
     if _plugin is None:
-        _plugin = custom_ops.get_plugin(
-            module_name='upfirdn2d_plugin',
-            sources=['upfirdn2d.cpp', 'upfirdn2d.cu'],
-            headers=['upfirdn2d.h'],
-            source_dir=os.path.dirname(__file__),
-            extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
-        )
-    return True
+        if custom_ops.use_ref_ops():
+            _plugin = False
+        else:
+            try:
+                _plugin = custom_ops.get_plugin(
+                    module_name='upfirdn2d_plugin',
+                    sources=['upfirdn2d.cpp', 'upfirdn2d.cu'],
+                    headers=['upfirdn2d.h'],
+                    source_dir=os.path.dirname(__file__),
+                    extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
+                )
+            except Exception as e:
+                _plugin = False
+                warnings.warn('Failed to build the upfirdn2d CUDA plugin; falling back to the (slower) reference '
+                              'PyTorch implementation. Check CUDA_HOME points to a full CUDA toolkit, or set '
+                              f'STYLEGAN3_USE_REF_OPS=1 to silence this warning. Build error:\n{e}')
+    return _plugin is not False
 
 def _parse_scaling(scaling):
     if isinstance(scaling, int):


### PR DESCRIPTION
## Summary
This PR significantly enhances the discriminator synthesis pipeline with anti-saturation controls to prevent color drift, improved video generation via direct ffmpeg subprocess calls, better Perlin noise implementation, and various quality-of-life improvements.

## Key Changes

### Anti-Saturation & Dream Improvements
- Added `DreamConfig` dataclass to control anti-saturation behavior (renormalization, soft clipping, gradient smoothing, jitter, flipping)
- Implemented `soft_clip()` for smooth tanh-family bounds instead of hard clamping
- Added `gaussian_blur()` for gradient smoothing to suppress high-frequency noise
- Refactored `dream()` to support per-sample batch processing with independent gradient normalization
- Added `renormalize()` to hold target mean/std across iterations, preventing drift to white
- Implemented `_resolve_target()` to capture and preserve starting image statistics
- Updated `deep_dream()` to accept preprocessed tensors and thread anti-saturation config through octaves
- Added `saturation_options()` decorator for reusable click CLI options across commands

### Video & Noise Generation
- Replaced ffmpeg-python dependency with direct subprocess calls via `save_video_ffmpeg()`
- Added `_ffmpeg_bin()` to locate ffmpeg binary with proper error handling
- Renamed `get_perlin_video()` to `get_perlin_volume()` and refactored to return numpy arrays
- Completely rewrote `FractalPerlin3D` with proper lattice-based Perlin noise implementation
- Improved noise normalization to stretch full [0, 255] range using min/max across entire volume
- Added support for solid color starting images via PIL's `ImageColor.getrgb()`
- Implemented `pad_to_multiple()` for seamless tiling to arbitrary input sizes

### Utility Functions
- Added `get_model_name()` to extract compact model names from paths/URLs
- Added `get_run_desc()` to build consistent run directory descriptions
- Added `layers_tag()` for compact layer set descriptions
- Added `get_padding_multiple()` to compute required input divisibility for arbitrary layer selections
- Updated normalization constants from ImageNet (0.485/0.456/0.406) to StyleGAN's [-1, 1] space (0.5/0.5/0.5)
- Vectorized `clip()` function for efficiency and device consistency
- Enhanced `deprocess()` to handle both tensors and numpy arrays, with batch support

### Code Quality
- Removed `torch.autograd.Variable` (deprecated in modern PyTorch)
- Replaced `scipy.ndimage.zoom` with `torch.nn.functional.interpolate` for on-device processing
- Improved `network_features.py` docstrings explaining layer availability and input constraints
- Added deterministic ordering in channel deduplication (sorted instead of set)
- Added graceful fallback for custom CUDA ops when compilation fails (`use_ref_ops()` escape hatch)
- Fixed image saving to not force 'RGB' mode (PIL infers from array)

### CLI Enhancements
- Changed `--random-image-noise` from choice to string type to accept color names/hex codes
- Added `--batch-size` option for batched dream processing
- Integrated anti-saturation options into `discriminator_dream` command with sensible defaults (jitter=8, flip=True for single images)
- Updated run directory naming to use `get_run_desc()` for consistency

## Notable Implementation Details
- Anti-saturation renormalization is computed once per full-resolution input and held across all octaves, locking global brightness/contrast to the starting image
- Gradient smoothing uses pytorch_ssim's Gaussian implementation for consistency
- Perlin noise is now isotropic and can be sliced along any axis while maintaining 2D noise properties
- Batch dream processing computes per-sample gradient norms for independent learning rates, enabling true batched synthesis
- Video generation now handles reverse video creation in a single subprocess call

https://claude.ai/code/session_012HfBa1SsXm1kWDc7WrWkYa